### PR TITLE
invalid multibyte char (US-ASCII) fix

### DIFF
--- a/lib/formatters/numbers/currency_formatter.rb
+++ b/lib/formatters/numbers/currency_formatter.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 module TwitterCldr
   module Formatters
     class CurrencyFormatter < NumberFormatter

--- a/lib/formatters/numbers/percent_formatter.rb
+++ b/lib/formatters/numbers/percent_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module TwitterCldr
   module Formatters
     class PercentFormatter < NumberFormatter

--- a/spec/ext/strings/symbol_spec.rb
+++ b/spec/ext/strings/symbol_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/formatters/numbers/number_formatter_spec.rb
+++ b/spec/formatters/numbers/number_formatter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters
 

--- a/spec/formatters/numbers/percent_formatter_spec.rb
+++ b/spec/formatters/numbers/percent_formatter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters
 

--- a/spec/shared/languages_spec.rb
+++ b/spec/shared/languages_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.join(File.dirname(__FILE__), %w[.. spec_helper])
 include TwitterCldr::Shared
 

--- a/spec/tokenizers/calendars/date_tokenizer_spec.rb
+++ b/spec/tokenizers/calendars/date_tokenizer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/calendars/time_tokenizer_spec.rb
+++ b/spec/tokenizers/calendars/time_tokenizer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/numbers/number_tokenizer_spec.rb
+++ b/spec/tokenizers/numbers/number_tokenizer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Tokenizers
 


### PR DESCRIPTION
Running a `build exec rake` on a clean fork is giving me a vomit of errors:

```
~/twitter-cldr-rb/spec/tokenizers/calendars/date_tokenizer_spec.rb:27: invalid multibyte char (US-ASCII)
~/twitter-cldr-rb/spec/tokenizers/calendars/date_tokenizer_spec.rb:27: syntax error, unexpected $end, expecting '}'
               { :value => "年", :type => :plaintext },
```

(imagine this, but fifteen different times)

There's a couple solutions to this, just asking for some opinions on what looks best:
- The main answer is to add a "magic comment" as seen on [Stack Overflow](http://stackoverflow.com/questions/3678172/ruby-1-9-invalid-multibyte-char-us-ascii). It's a one-liner that is added to every `.rb` file that uses non-ASCII characters.
- Second option is to use the [magic_encoding](https://github.com/m-ryan/magic_encoding) gem, which does this same thing for you, automatically. My assumption is that this is probably less likely to happen - it's nice that the current gem doesn't have any external requirements, and it's not unreasonable, in my opinion, to keep it that way.

I'm submitting a pull request with the first solution implemented. Adding nine one-liners instead of adding an external requirement makes sense to me. 
