### PR TITLE
Fix Tokenizer::Base#traverse without exceptions handling.

### DIFF
--- a/lib/tokenizers/base.rb
+++ b/lib/tokenizers/base.rb
@@ -50,12 +50,14 @@ module TwitterCldr
       end
 
       def traverse(needle, haystack = @resource)
-        segments = needle.to_s.split(".")
-        final = haystack
-        segments.each { |segment| final = final[segment.to_sym] }
-        final
-      rescue NameError
-        nil
+        needle.to_s.split('.').inject(haystack) do |current, segment|
+          key = segment.to_sym
+          if current.is_a?(Hash) && current.has_key?(key)
+            current[key]
+          else
+            return
+          end
+        end
       end
 
       def expand_pattern(format_str, type)


### PR DESCRIPTION
Fix for [this](https://github.com/twitter/twitter-cldr-rb/blob/master/spec/tokenizers/base_spec.rb#L110-112) test case. The downside is that we limit valid tree nodes to the instances of the `Hash` class. Though, if that's acceptable, I think this solution is better than the original one that blindly rescue every `NameError` exception (btw, is `NameError` the exception that should be rescued here?).
