### PR TITLE
Add '# encoding: UTF-8' to all Ruby files.

### DIFF
--- a/lib/ext/calendars/date.rb
+++ b/lib/ext/calendars/date.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Date
   def localize(locale = TwitterCldr.get_locale)
     TwitterCldr::LocalizedDate.new(self, locale)

--- a/lib/ext/calendars/datetime.rb
+++ b/lib/ext/calendars/datetime.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class DateTime
   def localize(locale = TwitterCldr.get_locale)
     TwitterCldr::LocalizedDateTime.new(self, locale)

--- a/lib/ext/calendars/time.rb
+++ b/lib/ext/calendars/time.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Time
   def localize(locale = TwitterCldr.get_locale)
     TwitterCldr::LocalizedTime.new(self, locale)

--- a/lib/ext/localized_object.rb
+++ b/lib/ext/localized_object.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   class LocalizedObject
     attr_reader :locale, :base_obj, :formatter

--- a/lib/ext/numbers/bignum.rb
+++ b/lib/ext/numbers/bignum.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Bignum
   include TwitterCldr::LocalizedNumberMixin
 end

--- a/lib/ext/numbers/fixnum.rb
+++ b/lib/ext/numbers/fixnum.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Fixnum
   include TwitterCldr::LocalizedNumberMixin
 end

--- a/lib/ext/numbers/float.rb
+++ b/lib/ext/numbers/float.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Float
   include TwitterCldr::LocalizedNumberMixin
 end

--- a/lib/ext/numbers/localized_number.rb
+++ b/lib/ext/numbers/localized_number.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module LocalizedNumberMixin
     def localize(locale = TwitterCldr.get_locale)

--- a/lib/ext/strings/symbol.rb
+++ b/lib/ext/strings/symbol.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class Symbol
   def localize(locale = TwitterCldr.get_locale)
     TwitterCldr::LocalizedSymbol.new(self, locale)

--- a/lib/formatters/base.rb
+++ b/lib/formatters/base.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     class Base

--- a/lib/formatters/calendars/date_formatter.rb
+++ b/lib/formatters/calendars/date_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     class DateFormatter < DateTimeFormatter

--- a/lib/formatters/calendars/datetime_formatter.rb
+++ b/lib/formatters/calendars/datetime_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 # This class has been adapted from Sven Fuch's ruby-cldr gem
 # See LICENSE for the accompanying license for his contributions
 

--- a/lib/formatters/calendars/time_formatter.rb
+++ b/lib/formatters/calendars/time_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     class TimeFormatter < DateTimeFormatter

--- a/lib/formatters/numbers/currency_formatter.rb
+++ b/lib/formatters/numbers/currency_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     class CurrencyFormatter < NumberFormatter

--- a/lib/formatters/numbers/decimal_formatter.rb
+++ b/lib/formatters/numbers/decimal_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     class DecimalFormatter < NumberFormatter

--- a/lib/formatters/numbers/helpers/base.rb
+++ b/lib/formatters/numbers/helpers/base.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     module Numbers

--- a/lib/formatters/numbers/helpers/fraction.rb
+++ b/lib/formatters/numbers/helpers/fraction.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     module Numbers

--- a/lib/formatters/numbers/helpers/integer.rb
+++ b/lib/formatters/numbers/helpers/integer.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     module Numbers

--- a/lib/formatters/numbers/number_formatter.rb
+++ b/lib/formatters/numbers/number_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     class NumberFormatter < Base

--- a/lib/formatters/numbers/percent_formatter.rb
+++ b/lib/formatters/numbers/percent_formatter.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     class PercentFormatter < NumberFormatter

--- a/lib/formatters/plurals/rules.rb
+++ b/lib/formatters/plurals/rules.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Formatters
     module Plurals

--- a/lib/shared/currencies.rb
+++ b/lib/shared/currencies.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Shared
     class Currencies

--- a/lib/shared/languages.rb
+++ b/lib/shared/languages.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Shared
     class Languages

--- a/lib/shared/resources.rb
+++ b/lib/shared/resources.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Shared
     class Resources

--- a/lib/shared/timezones.rb
+++ b/lib/shared/timezones.rb
@@ -1,1 +1,3 @@
+# encoding: UTF-8
+
 # not yet implemented

--- a/lib/tokenizers/base.rb
+++ b/lib/tokenizers/base.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Tokenizers
     class Base

--- a/lib/tokenizers/calendars/date_tokenizer.rb
+++ b/lib/tokenizers/calendars/date_tokenizer.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Tokenizers
     class DateTokenizer < TwitterCldr::Tokenizers::DateTimeTokenizer

--- a/lib/tokenizers/calendars/datetime_tokenizer.rb
+++ b/lib/tokenizers/calendars/datetime_tokenizer.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Tokenizers
     class DateTimeTokenizer < Base

--- a/lib/tokenizers/calendars/time_tokenizer.rb
+++ b/lib/tokenizers/calendars/time_tokenizer.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Tokenizers
     class TimeTokenizer < TwitterCldr::Tokenizers::DateTimeTokenizer

--- a/lib/tokenizers/key_path.rb
+++ b/lib/tokenizers/key_path.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Tokenizers
     class KeyPath

--- a/lib/tokenizers/numbers/number_tokenizer.rb
+++ b/lib/tokenizers/numbers/number_tokenizer.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Tokenizers
     class NumberTokenizer < Base

--- a/lib/tokenizers/token.rb
+++ b/lib/tokenizers/token.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module TwitterCldr
   module Tokenizers
     class Token

--- a/lib/twitter_cldr.rb
+++ b/lib/twitter_cldr.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 $:.push(File.dirname(__FILE__))
 
 require 'yaml'

--- a/spec/ext/calendars/date_spec.rb
+++ b/spec/ext/calendars/date_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/ext/calendars/datetime_spec.rb
+++ b/spec/ext/calendars/datetime_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/ext/calendars/time_spec.rb
+++ b/spec/ext/calendars/time_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/ext/numbers/bignum_spec.rb
+++ b/spec/ext/numbers/bignum_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/ext/numbers/fixnum_spec.rb
+++ b/spec/ext/numbers/fixnum_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/ext/numbers/float_spec.rb
+++ b/spec/ext/numbers/float_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/ext/numbers/localized_number_spec.rb
+++ b/spec/ext/numbers/localized_number_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/ext/strings/symbol_spec.rb
+++ b/spec/ext/strings/symbol_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr
 

--- a/spec/formatters/base_spec.rb
+++ b/spec/formatters/base_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(__FILE__), %w[.. spec_helper])
 include TwitterCldr::Formatters
 

--- a/spec/formatters/calendars/datetime_formatter_spec.rb
+++ b/spec/formatters/calendars/datetime_formatter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters
 

--- a/spec/formatters/numbers/currency_formatter_spec.rb
+++ b/spec/formatters/numbers/currency_formatter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters
 

--- a/spec/formatters/numbers/decimal_formatter_spec.rb
+++ b/spec/formatters/numbers/decimal_formatter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters
 

--- a/spec/formatters/numbers/helpers/fraction_spec.rb
+++ b/spec/formatters/numbers/helpers/fraction_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(File.dirname(__FILE__)))), "spec_helper")
 include TwitterCldr::Formatters::Numbers
 include TwitterCldr::Tokenizers

--- a/spec/formatters/numbers/helpers/integer_spec.rb
+++ b/spec/formatters/numbers/helpers/integer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(File.dirname(__FILE__)))), "spec_helper")
 include TwitterCldr::Formatters::Numbers
 include TwitterCldr::Tokenizers

--- a/spec/formatters/numbers/number_formatter_spec.rb
+++ b/spec/formatters/numbers/number_formatter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters
 

--- a/spec/formatters/numbers/percent_formatter_spec.rb
+++ b/spec/formatters/numbers/percent_formatter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters
 

--- a/spec/formatters/plurals/rules_spec.rb
+++ b/spec/formatters/plurals/rules_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Formatters::Plurals
 

--- a/spec/shared/currencies_spec.rb
+++ b/spec/shared/currencies_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(__FILE__), %w[.. spec_helper])
 include TwitterCldr::Shared
 

--- a/spec/shared/languages_spec.rb
+++ b/spec/shared/languages_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(__FILE__), %w[.. spec_helper])
 include TwitterCldr::Shared
 

--- a/spec/shared/resources_spec.rb
+++ b/spec/shared/resources_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(__FILE__), %w[.. spec_helper])
 include TwitterCldr::Shared
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.expand_path(File.join(File.dirname(__FILE__), %w[.. lib twitter_cldr]))
 FIXTURE_DIR = File.expand_path(File.join(File.dirname(__FILE__), %w[fixtures]))
 

--- a/spec/tokenizers/base_spec.rb
+++ b/spec/tokenizers/base_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(__FILE__)), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/calendars/date_tokenizer_spec.rb
+++ b/spec/tokenizers/calendars/date_tokenizer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/calendars/datetime_tokenizer_spec.rb
+++ b/spec/tokenizers/calendars/datetime_tokenizer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/calendars/time_tokenizer_spec.rb
+++ b/spec/tokenizers/calendars/time_tokenizer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/key_path_spec.rb
+++ b/spec/tokenizers/key_path_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(__FILE__)), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/numbers/number_tokenizer_spec.rb
+++ b/spec/tokenizers/numbers/number_tokenizer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(File.dirname(__FILE__))), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/tokenizers/token_spec.rb
+++ b/spec/tokenizers/token_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(File.dirname(__FILE__)), "spec_helper")
 include TwitterCldr::Tokenizers
 

--- a/spec/twitter_cldr_spec.rb
+++ b/spec/twitter_cldr_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require File.join(File.dirname(__FILE__), "spec_helper")
 
 describe TwitterCldr do


### PR DESCRIPTION
Addresses the same issue as #4, but with a fewer commits =) 

I think you can merge it as an initial solution for encoding problems on 1.9. Afaik 1.8 simply ignores magic comments so it shouldn't cause any problems for this Ruby version. You can add some special logic for 1.8 involving `$KCODE` later if you think that's necessary.
