### PR TITLE
$KCODE variable added and dependent on RUBY_VERSION

### DIFF
--- a/lib/twitter_cldr.rb
+++ b/lib/twitter_cldr.rb
@@ -2,6 +2,8 @@
 
 $:.push(File.dirname(__FILE__))
 
+$KCODE = 'UTF-8' unless RUBY_VERSION >= '1.9.0'
+
 require 'yaml'
 require 'date'
 require 'time'


### PR DESCRIPTION
We discussed the `$KCODE` solution in a previous pull request, in order to accomplish the same thing the magic comments do for 1.9. This branch enables that and additionally only executes on versions of Ruby older than 1.9.0.
