### PR TITLE
Use String[Fixnum, Fixnum] syntax to get the first character of the line.

### DIFF
--- a/spec/normalizers/canonical/nfd_spec.rb
+++ b/spec/normalizers/canonical/nfd_spec.rb
@@ -35,7 +35,7 @@ describe NFD do
       normalization_test_file = File.join(File.dirname(File.dirname(__FILE__)), "NormalizationTest.txt")
       File.open(normalization_test_file, "r:UTF-8") do |file|
         while line = file.gets
-          unless line =~ /(@|#)/ || line.empty?
+          unless line[0,1] =~ /(@|#)/ || line.empty?
             c1, c2, c3, c4, c5 = line.split(';')[0...5].map { |cps| cps.split }
             NFD.normalize_code_points(c1).should == c3
             NFD.normalize_code_points(c2).should == c3


### PR DESCRIPTION
In `nfd_spec.rb`, we test against NormalizationTest.txt. This file has commented lines beginning with `#` or `@` that must be ignored. To do this, we used something like:

``` ruby
unless line[0] =~ /(@|#)/
  # Process line
end
```

This didn't work in Ruby 1.8.7, because str[index] gives you the `character code` of the character at index ([ref](http://ruby-doc.org/core-1.8.7/String.html#method-i-5B-5D)), while 1.9.2 gives you the character itself ([ref](http://ruby-doc.org/core-1.9.3/String.html#method-i-5B-5D)). So we use the str[index,length] syntax to get the first character which works in 1.8.7 and 1.9.2.
