### PR TITLE
Remove duplicated method.

### DIFF
--- a/lib/ext/numbers/localized_number.rb
+++ b/lib/ext/numbers/localized_number.rb
@@ -29,10 +29,6 @@ module TwitterCldr
       self
     end
 
-    def plural_rule
-      TwitterCldr::Formatters::Plurals::Rules.rule_for(@base_obj, @locale)
-    end
-
     def to_s(options = {})
       opts = options
       opts = { :precision => 0 }.merge(opts) if @base_obj.is_a?(Fixnum)


### PR DESCRIPTION
There are two [identical](https://github.com/twitter/twitter-cldr-rb/blob/master/lib/ext/numbers/localized_number.rb#L32-34) [methods](https://github.com/twitter/twitter-cldr-rb/blob/master/lib/ext/numbers/localized_number.rb#L42-44).
