### PR TITLE
Fix 'uninitialized constant' errors in localized classes specs.

### DIFF
--- a/spec/normalization/base_spec.rb
+++ b/spec/normalization/base_spec.rb
@@ -5,13 +5,13 @@
 
 require 'spec_helper'
 
-include TwitterCldr::Normalization
+include TwitterCldr
 
 describe Base do
   describe "#combining_class_for" do
     it "returns the correct combining class for select code points" do
-      Base.combining_class_for(0x303).should == 230  # combining tilde
-      Base.combining_class_for(0x6E).should  == 0    # latin letter n
+      Normalization::Base.combining_class_for(0x303).should == 230  # combining tilde
+      Normalization::Base.combining_class_for(0x6E).should  == 0    # latin letter n
     end
   end
 end


### PR DESCRIPTION
For some reason it wasn't failing until now.
