### PR TITLE
Adding custom plural rule resource for Hungarian

### DIFF
--- a/resources/custom/locales/hu/plurals.yml
+++ b/resources/custom/locales/hu/plurals.yml
@@ -1,0 +1,3 @@
+---
+:hu: ! '{ :hu => { :i18n => {:plural => { :keys => [:one, :other], :rule => lambda
+  { |n| n == 1 ? :one : :other } } } } }'


### PR DESCRIPTION
Additional data that CLDR doesn't have :)  Unfortunately this is pretty Twitter-specific, but Hungarian plurals are also rather flexible.  It shouldn't be a problem to include this in the gem.
