### PR TITLE
allow core-ext opt-out

### DIFF
--- a/lib/twitter_cldr.rb
+++ b/lib/twitter_cldr.rb
@@ -141,4 +141,4 @@ end
 
 TwitterCldr.reset_locale_fallbacks
 
-require 'twitter_cldr/core_ext'
+require 'twitter_cldr/core_ext' unless defined?(TwitterCldr::NO_CORE_EXT)


### PR DESCRIPTION
We are trying to use twitter-cldr as a pure data-source to fill our ui, and don't want all the core-ext
