### PR TITLE
Update Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
   allow_failures:
     - rvm: jruby-head
 env:
-  - 'RSPEC_COMMAND="--tag ~slow spec"'
-  - 'RSPEC_COMMAND="--tag slow spec/bidi/bidi_spec.rb spec/collation/collation_spec.rb"'
-  - 'RSPEC_COMMAND="--tag slow spec/collation/tailoring_spec.rb spec/collation/trie_dumps_spec.rb"'
-  - 'RSPEC_COMMAND="--tag slow spec/normalization/normalization_spec.rb"'
-script: 'bundle exec rspec $RSPEC_COMMAND'
+  - 'RSPEC_OPTIONS="--tag ~slow spec"'
+  - 'RSPEC_OPTIONS="--tag slow spec/bidi/bidi_spec.rb spec/collation/collation_spec.rb"'
+  - 'RSPEC_OPTIONS="--tag slow spec/collation/tailoring_spec.rb spec/collation/trie_dumps_spec.rb"'
+  - 'RSPEC_OPTIONS="--tag slow spec/normalization/normalization_spec.rb"'
+script: 'bundle exec rspec $RSPEC_OPTIONS'
 before_script: 'gem install bundler'


### PR DESCRIPTION
I was wondering if TwitterCLDR's build matrix for Travis CI is complete and noticed that [parsers specs](https://github.com/twitter/twitter-cldr-rb/tree/f0f8550ee658eeb94feab2a5fb81cf608f5ae804/spec/parsers) are missing (check out, for example, [this build](https://travis-ci.org/twitter/twitter-cldr-rb/builds/4582217)).

It's pretty hard to remember to update build matrix every time a new specs directory is added, so I suggest to change the build matrix a bit. If all "fast" specs are executed at once (using `rspec --tag ~slow spec`) none of them will ever be forgotten or skipped on Travis. All "slow" specs, as before, can be executed separately in small groups to make sure they fit into the time limit for Travis builds. If new "slow" specs are added, they will have to be added to the build matrix manually, but I believe that new "fast" specs are added much more often than the "slow" ones, so it shouldn't be that annoying.

Check out [this build](https://travis-ci.org/KL-7/twitter-cldr-rb/builds/4740981) – if I counted them correctly, all specs are executed and the maximum time for a specs batch is even smaller than [before](https://travis-ci.org/twitter/twitter-cldr-rb/builds/4582217) (though, it isn't the main goal).
