### PR TITLE
Scopes postal code to the beginning/end of string

### DIFF
--- a/README.md.erb
+++ b/README.md.erb
@@ -429,7 +429,7 @@ TwitterCldr::Shared::PostalCodes.territories  # <%= ellipsize(assert(TwitterCldr
 Just want the regex?  No problem:
 
 ```ruby
-TwitterCldr::Shared::PostalCodes.regex_for_territory(:us)  # <%= assert(TwitterCldr::Shared::PostalCodes.regex_for_territory(:us), /\d{5}([ \-]\d{4})?/).inspect %>
+TwitterCldr::Shared::PostalCodes.regex_for_territory(:us)  # <%= assert(TwitterCldr::Shared::PostalCodes.regex_for_territory(:us), /\A\d{5}([ \-]\d{4})?\z/).inspect %>
 ```
 
 ### Phone Codes

--- a/lib/twitter_cldr/resources/postal_codes_importer.rb
+++ b/lib/twitter_cldr/resources/postal_codes_importer.rb
@@ -30,7 +30,7 @@ module TwitterCldr
         doc = File.open(File.join(@input_path, POSTAL_CODES_PATH)) { |file| Nokogiri::XML(file) }
 
         postal_codes = doc.xpath('//postCodeRegex').inject({}) do |memo, node|
-          memo[node.attr('territoryId').downcase.to_sym] = Regexp.new(node.text); memo
+          memo[node.attr('territoryId').downcase.to_sym] = Regexp.new("\\A#{node.text}\\z"); memo
         end
 
         postal_codes = Hash[postal_codes.sort_by(&:first)]

--- a/resources/shared/postal_codes.yml
+++ b/resources/shared/postal_codes.yml
@@ -1,160 +1,160 @@
 ---
-:ad: !ruby/regexp '/AD\d{3}/'
-:am: !ruby/regexp '/(37)?\d{4}/'
-:ar: !ruby/regexp '/([A-HJ-NP-Z])?\d{4}([A-Z]{3})?/'
-:as: !ruby/regexp '/96799/'
-:at: !ruby/regexp '/\d{4}/'
-:au: !ruby/regexp '/\d{4}/'
-:ax: !ruby/regexp '/22\d{3}/'
-:az: !ruby/regexp '/\d{4}/'
-:ba: !ruby/regexp '/\d{5}/'
-:bb: !ruby/regexp '/(BB\d{5})?/'
-:bd: !ruby/regexp '/\d{4}/'
-:be: !ruby/regexp '/\d{4}/'
-:bg: !ruby/regexp '/\d{4}/'
-:bh: !ruby/regexp '/((1[0-2]|[2-9])\d{2})?/'
-:bm: !ruby/regexp '/[A-Z]{2}[ ]?[A-Z0-9]{2}/'
-:bn: !ruby/regexp '/[A-Z]{2}[ ]?\d{4}/'
-:br: !ruby/regexp '/\d{5}[\-]?\d{3}/'
-:by: !ruby/regexp '/\d{6}/'
-:ca: !ruby/regexp '/[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ ]?\d[ABCEGHJ-NPRSTV-Z]\d/'
-:cc: !ruby/regexp '/6799/'
-:ch: !ruby/regexp '/\d{4}/'
-:ck: !ruby/regexp '/\d{4}/'
-:cl: !ruby/regexp '/\d{7}/'
-:cn: !ruby/regexp '/\d{6}/'
-:cr: !ruby/regexp '/\d{4,5}|\d{3}-\d{4}/'
-:cs: !ruby/regexp '/\d{5}/'
-:cv: !ruby/regexp '/\d{4}/'
-:cx: !ruby/regexp '/6798/'
-:cy: !ruby/regexp '/\d{4}/'
-:cz: !ruby/regexp '/\d{3}[ ]?\d{2}/'
-:de: !ruby/regexp '/\d{5}/'
-:dk: !ruby/regexp '/\d{4}/'
-:do: !ruby/regexp '/\d{5}/'
-:dz: !ruby/regexp '/\d{5}/'
-:ec: !ruby/regexp '/([A-Z]\d{4}[A-Z]|(?:[A-Z]{2})?\d{6})?/'
-:ee: !ruby/regexp '/\d{5}/'
-:eg: !ruby/regexp '/\d{5}/'
-:es: !ruby/regexp '/\d{5}/'
-:et: !ruby/regexp '/\d{4}/'
-:fi: !ruby/regexp '/\d{5}/'
-:fk: !ruby/regexp '/FIQQ 1ZZ/'
-:fm: !ruby/regexp '/(9694[1-4])([ \-]\d{4})?/'
-:fo: !ruby/regexp '/\d{3}/'
-:fr: !ruby/regexp '/\d{2}[ ]?\d{3}/'
-:gb: !ruby/regexp '/GIR[ ]?0AA|((AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(\d[\dA-Z]?[
-  ]?\d[ABD-HJLN-UW-Z]{2}))|BFPO[ ]?\d{1,4}/'
-:ge: !ruby/regexp '/\d{4}/'
-:gf: !ruby/regexp '/9[78]3\d{2}/'
-:gg: !ruby/regexp '/GY\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}/'
-:gl: !ruby/regexp '/39\d{2}/'
-:gn: !ruby/regexp '/\d{3}/'
-:gp: !ruby/regexp '/9[78][01]\d{2}/'
-:gr: !ruby/regexp '/\d{3}[ ]?\d{2}/'
-:gs: !ruby/regexp '/SIQQ 1ZZ/'
-:gt: !ruby/regexp '/\d{5}/'
-:gu: !ruby/regexp '/969[123]\d([ \-]\d{4})?/'
-:gw: !ruby/regexp '/\d{4}/'
-:hm: !ruby/regexp '/\d{4}/'
-:hn: !ruby/regexp '/(?:\d{5})?/'
-:hr: !ruby/regexp '/\d{5}/'
-:ht: !ruby/regexp '/\d{4}/'
-:hu: !ruby/regexp '/\d{4}/'
-:id: !ruby/regexp '/\d{5}/'
-:ie: !ruby/regexp '/((D|DUBLIN)?([1-9]|6[wW]|1[0-8]|2[024]))?/'
-:il: !ruby/regexp '/\d{5}/'
-:im: !ruby/regexp '/IM\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}/'
-:in: !ruby/regexp '/\d{6}/'
-:io: !ruby/regexp '/BBND 1ZZ/'
-:iq: !ruby/regexp '/\d{5}/'
-:is: !ruby/regexp '/\d{3}/'
-:it: !ruby/regexp '/\d{5}/'
-:je: !ruby/regexp '/JE\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}/'
-:jo: !ruby/regexp '/\d{5}/'
-:jp: !ruby/regexp '/\d{3}-\d{4}/'
-:ke: !ruby/regexp '/\d{5}/'
-:kg: !ruby/regexp '/\d{6}/'
-:kh: !ruby/regexp '/\d{5}/'
-:kr: !ruby/regexp '/\d{3}[\-]\d{3}/'
-:kw: !ruby/regexp '/\d{5}/'
-:kz: !ruby/regexp '/\d{6}/'
-:la: !ruby/regexp '/\d{5}/'
-:lb: !ruby/regexp '/(\d{4}([ ]?\d{4})?)?/'
-:li: !ruby/regexp '/(948[5-9])|(949[0-7])/'
-:lk: !ruby/regexp '/\d{5}/'
-:lr: !ruby/regexp '/\d{4}/'
-:ls: !ruby/regexp '/\d{3}/'
-:lt: !ruby/regexp '/\d{5}/'
-:lu: !ruby/regexp '/\d{4}/'
-:lv: !ruby/regexp '/\d{4}/'
-:ma: !ruby/regexp '/\d{5}/'
-:mc: !ruby/regexp '/980\d{2}/'
-:md: !ruby/regexp '/\d{4}/'
-:me: !ruby/regexp '/8\d{4}/'
-:mg: !ruby/regexp '/\d{3}/'
-:mh: !ruby/regexp '/969[67]\d([ \-]\d{4})?/'
-:mk: !ruby/regexp '/\d{4}/'
-:mn: !ruby/regexp '/\d{6}/'
-:mp: !ruby/regexp '/9695[012]([ \-]\d{4})?/'
-:mq: !ruby/regexp '/9[78]2\d{2}/'
-:mt: !ruby/regexp '/[A-Z]{3}[ ]?\d{2,4}/'
-:mu: !ruby/regexp '/(\d{3}[A-Z]{2}\d{3})?/'
-:mv: !ruby/regexp '/\d{5}/'
-:mx: !ruby/regexp '/\d{5}/'
-:my: !ruby/regexp '/\d{5}/'
-:nc: !ruby/regexp '/988\d{2}/'
-:ne: !ruby/regexp '/\d{4}/'
-:nf: !ruby/regexp '/2899/'
-:ng: !ruby/regexp '/(\d{6})?/'
-:ni: !ruby/regexp '/((\d{4}-)?\d{3}-\d{3}(-\d{1})?)?/'
-:nl: !ruby/regexp '/\d{4}[ ]?[A-Z]{2}/'
-:no: !ruby/regexp '/\d{4}/'
-:np: !ruby/regexp '/\d{5}/'
-:nz: !ruby/regexp '/\d{4}/'
-:om: !ruby/regexp '/(PC )?\d{3}/'
-:pf: !ruby/regexp '/987\d{2}/'
-:pg: !ruby/regexp '/\d{3}/'
-:ph: !ruby/regexp '/\d{4}/'
-:pk: !ruby/regexp '/\d{5}/'
-:pl: !ruby/regexp '/\d{2}-\d{3}/'
-:pm: !ruby/regexp '/9[78]5\d{2}/'
-:pn: !ruby/regexp '/PCRN 1ZZ/'
-:pr: !ruby/regexp '/00[679]\d{2}([ \-]\d{4})?/'
-:pt: !ruby/regexp '/\d{4}([\-]\d{3})?/'
-:pw: !ruby/regexp '/96940/'
-:py: !ruby/regexp '/\d{4}/'
-:re: !ruby/regexp '/9[78]4\d{2}/'
-:ro: !ruby/regexp '/\d{6}/'
-:rs: !ruby/regexp '/\d{6}/'
-:ru: !ruby/regexp '/\d{6}/'
-:sa: !ruby/regexp '/\d{5}/'
-:se: !ruby/regexp '/\d{3}[ ]?\d{2}/'
-:sg: !ruby/regexp '/\d{6}/'
-:sh: !ruby/regexp '/(ASCN|STHL) 1ZZ/'
-:si: !ruby/regexp '/\d{4}/'
-:sj: !ruby/regexp '/\d{4}/'
-:sk: !ruby/regexp '/\d{3}[ ]?\d{2}/'
-:sm: !ruby/regexp '/4789\d/'
-:sn: !ruby/regexp '/\d{5}/'
-:so: !ruby/regexp '/\d{5}/'
-:sz: !ruby/regexp '/[HLMS]\d{3}/'
-:tc: !ruby/regexp '/TKCA 1ZZ/'
-:th: !ruby/regexp '/\d{5}/'
-:tj: !ruby/regexp '/\d{6}/'
-:tm: !ruby/regexp '/\d{6}/'
-:tn: !ruby/regexp '/\d{4}/'
-:tr: !ruby/regexp '/\d{5}/'
-:tw: !ruby/regexp '/\d{3}(\d{2})?/'
-:ua: !ruby/regexp '/\d{5}/'
-:us: !ruby/regexp '/\d{5}([ \-]\d{4})?/'
-:uy: !ruby/regexp '/\d{5}/'
-:uz: !ruby/regexp '/\d{6}/'
-:va: !ruby/regexp '/00120/'
-:ve: !ruby/regexp '/\d{4}/'
-:vi: !ruby/regexp '/008(([0-4]\d)|(5[01]))([ \-]\d{4})?/'
-:wf: !ruby/regexp '/986\d{2}/'
-:yt: !ruby/regexp '/976\d{2}/'
-:yu: !ruby/regexp '/\d{5}/'
-:za: !ruby/regexp '/\d{4}/'
-:zm: !ruby/regexp '/\d{5}/'
+:ad: !ruby/regexp /\AAD\d{3}\z/
+:am: !ruby/regexp /\A(37)?\d{4}\z/
+:ar: !ruby/regexp /\A([A-HJ-NP-Z])?\d{4}([A-Z]{3})?\z/
+:as: !ruby/regexp /\A96799\z/
+:at: !ruby/regexp /\A\d{4}\z/
+:au: !ruby/regexp /\A\d{4}\z/
+:ax: !ruby/regexp /\A22\d{3}\z/
+:az: !ruby/regexp /\A\d{4}\z/
+:ba: !ruby/regexp /\A\d{5}\z/
+:bb: !ruby/regexp /\A(BB\d{5})?\z/
+:bd: !ruby/regexp /\A\d{4}\z/
+:be: !ruby/regexp /\A\d{4}\z/
+:bg: !ruby/regexp /\A\d{4}\z/
+:bh: !ruby/regexp /\A((1[0-2]|[2-9])\d{2})?\z/
+:bm: !ruby/regexp /\A[A-Z]{2}[ ]?[A-Z0-9]{2}\z/
+:bn: !ruby/regexp /\A[A-Z]{2}[ ]?\d{4}\z/
+:br: !ruby/regexp /\A\d{5}[\-]?\d{3}\z/
+:by: !ruby/regexp /\A\d{6}\z/
+:ca: !ruby/regexp /\A[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ ]?\d[ABCEGHJ-NPRSTV-Z]\d\z/
+:cc: !ruby/regexp /\A6799\z/
+:ch: !ruby/regexp /\A\d{4}\z/
+:ck: !ruby/regexp /\A\d{4}\z/
+:cl: !ruby/regexp /\A\d{7}\z/
+:cn: !ruby/regexp /\A\d{6}\z/
+:cr: !ruby/regexp /\A\d{4,5}|\d{3}-\d{4}\z/
+:cs: !ruby/regexp /\A\d{5}\z/
+:cv: !ruby/regexp /\A\d{4}\z/
+:cx: !ruby/regexp /\A6798\z/
+:cy: !ruby/regexp /\A\d{4}\z/
+:cz: !ruby/regexp /\A\d{3}[ ]?\d{2}\z/
+:de: !ruby/regexp /\A\d{5}\z/
+:dk: !ruby/regexp /\A\d{4}\z/
+:do: !ruby/regexp /\A\d{5}\z/
+:dz: !ruby/regexp /\A\d{5}\z/
+:ec: !ruby/regexp /\A([A-Z]\d{4}[A-Z]|(?:[A-Z]{2})?\d{6})?\z/
+:ee: !ruby/regexp /\A\d{5}\z/
+:eg: !ruby/regexp /\A\d{5}\z/
+:es: !ruby/regexp /\A\d{5}\z/
+:et: !ruby/regexp /\A\d{4}\z/
+:fi: !ruby/regexp /\A\d{5}\z/
+:fk: !ruby/regexp /\AFIQQ 1ZZ\z/
+:fm: !ruby/regexp /\A(9694[1-4])([ \-]\d{4})?\z/
+:fo: !ruby/regexp /\A\d{3}\z/
+:fr: !ruby/regexp /\A\d{2}[ ]?\d{3}\z/
+:gb: !ruby/regexp /\AGIR[ ]?0AA|((AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(\d[\dA-Z]?[
+  ]?\d[ABD-HJLN-UW-Z]{2}))|BFPO[ ]?\d{1,4}\z/
+:ge: !ruby/regexp /\A\d{4}\z/
+:gf: !ruby/regexp /\A9[78]3\d{2}\z/
+:gg: !ruby/regexp /\AGY\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}\z/
+:gl: !ruby/regexp /\A39\d{2}\z/
+:gn: !ruby/regexp /\A\d{3}\z/
+:gp: !ruby/regexp /\A9[78][01]\d{2}\z/
+:gr: !ruby/regexp /\A\d{3}[ ]?\d{2}\z/
+:gs: !ruby/regexp /\ASIQQ 1ZZ\z/
+:gt: !ruby/regexp /\A\d{5}\z/
+:gu: !ruby/regexp /\A969[123]\d([ \-]\d{4})?\z/
+:gw: !ruby/regexp /\A\d{4}\z/
+:hm: !ruby/regexp /\A\d{4}\z/
+:hn: !ruby/regexp /\A(?:\d{5})?\z/
+:hr: !ruby/regexp /\A\d{5}\z/
+:ht: !ruby/regexp /\A\d{4}\z/
+:hu: !ruby/regexp /\A\d{4}\z/
+:id: !ruby/regexp /\A\d{5}\z/
+:il: !ruby/regexp /\A\d{5}\z/
+:im: !ruby/regexp /\AIM\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}\z/
+:in: !ruby/regexp /\A\d{6}\z/
+:io: !ruby/regexp /\ABBND 1ZZ\z/
+:iq: !ruby/regexp /\A\d{5}\z/
+:is: !ruby/regexp /\A\d{3}\z/
+:it: !ruby/regexp /\A\d{5}\z/
+:je: !ruby/regexp /\AJE\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}\z/
+:jo: !ruby/regexp /\A\d{5}\z/
+:jp: !ruby/regexp /\A\d{3}-\d{4}\z/
+:ke: !ruby/regexp /\A\d{5}\z/
+:kg: !ruby/regexp /\A\d{6}\z/
+:kh: !ruby/regexp /\A\d{5}\z/
+:kr: !ruby/regexp /\A\d{3}[\-]\d{3}\z/
+:kw: !ruby/regexp /\A\d{5}\z/
+:kz: !ruby/regexp /\A\d{6}\z/
+:la: !ruby/regexp /\A\d{5}\z/
+:lb: !ruby/regexp /\A(\d{4}([ ]?\d{4})?)?\z/
+:li: !ruby/regexp /\A(948[5-9])|(949[0-7])\z/
+:lk: !ruby/regexp /\A\d{5}\z/
+:lr: !ruby/regexp /\A\d{4}\z/
+:ls: !ruby/regexp /\A\d{3}\z/
+:lt: !ruby/regexp /\A\d{5}\z/
+:lu: !ruby/regexp /\A\d{4}\z/
+:lv: !ruby/regexp /\A\d{4}\z/
+:ma: !ruby/regexp /\A\d{5}\z/
+:mc: !ruby/regexp /\A980\d{2}\z/
+:md: !ruby/regexp /\A\d{4}\z/
+:me: !ruby/regexp /\A8\d{4}\z/
+:mg: !ruby/regexp /\A\d{3}\z/
+:mh: !ruby/regexp /\A969[67]\d([ \-]\d{4})?\z/
+:mk: !ruby/regexp /\A\d{4}\z/
+:mn: !ruby/regexp /\A\d{6}\z/
+:mp: !ruby/regexp /\A9695[012]([ \-]\d{4})?\z/
+:mq: !ruby/regexp /\A9[78]2\d{2}\z/
+:mt: !ruby/regexp /\A[A-Z]{3}[ ]?\d{2,4}\z/
+:mu: !ruby/regexp /\A(\d{3}[A-Z]{2}\d{3})?\z/
+:mv: !ruby/regexp /\A\d{5}\z/
+:mx: !ruby/regexp /\A\d{5}\z/
+:my: !ruby/regexp /\A\d{5}\z/
+:nc: !ruby/regexp /\A988\d{2}\z/
+:ne: !ruby/regexp /\A\d{4}\z/
+:nf: !ruby/regexp /\A2899\z/
+:ng: !ruby/regexp /\A(\d{6})?\z/
+:ni: !ruby/regexp /\A((\d{4}-)?\d{3}-\d{3}(-\d{1})?)?\z/
+:nl: !ruby/regexp /\A\d{4}[ ]?[A-Z]{2}\z/
+:no: !ruby/regexp /\A\d{4}\z/
+:np: !ruby/regexp /\A\d{5}\z/
+:nz: !ruby/regexp /\A\d{4}\z/
+:om: !ruby/regexp /\A(PC )?\d{3}\z/
+:pf: !ruby/regexp /\A987\d{2}\z/
+:pg: !ruby/regexp /\A\d{3}\z/
+:ph: !ruby/regexp /\A\d{4}\z/
+:pk: !ruby/regexp /\A\d{5}\z/
+:pl: !ruby/regexp /\A\d{2}-\d{3}\z/
+:pm: !ruby/regexp /\A9[78]5\d{2}\z/
+:pn: !ruby/regexp /\APCRN 1ZZ\z/
+:pr: !ruby/regexp /\A00[679]\d{2}([ \-]\d{4})?\z/
+:pt: !ruby/regexp /\A\d{4}([\-]\d{3})?\z/
+:pw: !ruby/regexp /\A96940\z/
+:py: !ruby/regexp /\A\d{4}\z/
+:re: !ruby/regexp /\A9[78]4\d{2}\z/
+:ro: !ruby/regexp /\A\d{6}\z/
+:rs: !ruby/regexp /\A\d{6}\z/
+:ru: !ruby/regexp /\A\d{6}\z/
+:sa: !ruby/regexp /\A\d{5}\z/
+:se: !ruby/regexp /\A\d{3}[ ]?\d{2}\z/
+:sg: !ruby/regexp /\A\d{6}\z/
+:sh: !ruby/regexp /\A(ASCN|STHL) 1ZZ\z/
+:si: !ruby/regexp /\A\d{4}\z/
+:sj: !ruby/regexp /\A\d{4}\z/
+:sk: !ruby/regexp /\A\d{3}[ ]?\d{2}\z/
+:sm: !ruby/regexp /\A4789\d\z/
+:sn: !ruby/regexp /\A\d{5}\z/
+:so: !ruby/regexp /\A\d{5}\z/
+:sz: !ruby/regexp /\A[HLMS]\d{3}\z/
+:tc: !ruby/regexp /\ATKCA 1ZZ\z/
+:th: !ruby/regexp /\A\d{5}\z/
+:tj: !ruby/regexp /\A\d{6}\z/
+:tm: !ruby/regexp /\A\d{6}\z/
+:tn: !ruby/regexp /\A\d{4}\z/
+:tr: !ruby/regexp /\A\d{5}\z/
+:tw: !ruby/regexp /\A\d{3}(\d{2})?\z/
+:ua: !ruby/regexp /\A\d{5}\z/
+:us: !ruby/regexp /\A\d{5}([ \-]\d{4})?\z/
+:uy: !ruby/regexp /\A\d{5}\z/
+:uz: !ruby/regexp /\A\d{6}\z/
+:va: !ruby/regexp /\A00120\z/
+:ve: !ruby/regexp /\A\d{4}\z/
+:vi: !ruby/regexp /\A008(([0-4]\d)|(5[01]))([ \-]\d{4})?\z/
+:wf: !ruby/regexp /\A986\d{2}\z/
+:xk: !ruby/regexp /\A\d{5}\z/
+:yt: !ruby/regexp /\A976\d{2}\z/
+:yu: !ruby/regexp /\A\d{5}\z/
+:za: !ruby/regexp /\A\d{4}\z/
+:zm: !ruby/regexp /\A\d{5}\z/


### PR DESCRIPTION
Regexes for the postal codes were being generated withouth beginning/end
scopes, so any string having a match in between was considered valid.
