### PR TITLE
Bump RSpec to ~> 2.14.0 and convert expect syntax with transpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ group :development do
 end
 
 group :test do
-  gem 'rspec', '~> 2.11.0'
-  gem 'rr',    '~> 1.0.4'
+  gem 'rspec', '~> 2.14.0'
+  gem 'rr',    '~> 1.1.2'
 
   if RUBY_VERSION >= "1.9"
     gem 'rubyzip'

--- a/spec/bidi/bidi_spec.rb
+++ b/spec/bidi/bidi_spec.rb
@@ -67,6 +67,6 @@ describe Bidi do
       end
     end
 
-    num_failed.should == 0
+    expect(num_failed).to eq(0)
   end
 end

--- a/spec/collation/collation_spec.rb
+++ b/spec/collation/collation_spec.rb
@@ -41,7 +41,7 @@ describe 'Unicode Collation Algorithm' do
 
         if previous_sort_key
           result = (previous_sort_key <=> current_sort_key).nonzero? || (previous_code_points <=> current_code_points)
-          result.should(eq(-1), error_message(previous_str_code_points, previous_sort_key, current_str_code_points, current_sort_key))
+          expect(result).to(eq(-1), error_message(previous_str_code_points, previous_sort_key, current_str_code_points, current_sort_key))
         end
 
         previous_sort_key        = current_sort_key

--- a/spec/collation/collator_spec.rb
+++ b/spec/collation/collator_spec.rb
@@ -21,15 +21,15 @@ describe Collator do
     end
 
     it 'returns default fractional collation elements trie' do
-      Collator.default_trie.should == trie
+      expect(Collator.default_trie).to eq(trie)
     end
 
     it 'loads the trie only once' do
-      Collator.default_trie.object_id.should == Collator.default_trie.object_id
+      expect(Collator.default_trie.object_id).to eq(Collator.default_trie.object_id)
     end
 
     it 'locks the trie' do
-      Collator.default_trie.should be_locked
+      expect(Collator.default_trie).to be_locked
     end
   end
 
@@ -43,15 +43,15 @@ describe Collator do
     end
 
     it 'returns default fractional collation elements trie' do
-      Collator.tailored_trie(locale).should == trie
+      expect(Collator.tailored_trie(locale)).to eq(trie)
     end
 
     it 'loads the trie only once' do
-      Collator.tailored_trie(locale).object_id.should == Collator.tailored_trie(locale).object_id
+      expect(Collator.tailored_trie(locale).object_id).to eq(Collator.tailored_trie(locale).object_id)
     end
 
     it 'locks the trie' do
-      Collator.tailored_trie(locale).should be_locked
+      expect(Collator.tailored_trie(locale)).to be_locked
     end
   end
 
@@ -62,17 +62,17 @@ describe Collator do
 
     context 'without locale' do
       it 'initializes default collator' do
-        Collator.new.locale.should be_nil
+        expect(Collator.new.locale).to be_nil
       end
     end
 
     context 'with locale' do
       it 'initialized tailored collator with provided locale' do
-        Collator.new(:ru).locale.should == :ru
+        expect(Collator.new(:ru).locale).to eq(:ru)
       end
 
       it 'converts locale' do
-        Collator.new(:no).locale.should == :nb
+        expect(Collator.new(:no).locale).to eq(:nb)
       end
     end
   end
@@ -90,11 +90,11 @@ describe Collator do
     end
 
     it 'returns collation elements for a string' do
-      collator.get_collation_elements(string).should == collation_elements
+      expect(collator.get_collation_elements(string)).to eq(collation_elements)
     end
 
     it 'returns collation elements for an array of code points (represented as hex strings)' do
-      collator.get_collation_elements(code_points).should == collation_elements
+      expect(collator.get_collation_elements(code_points)).to eq(collation_elements)
     end
   end
 
@@ -112,12 +112,12 @@ describe Collator do
 
       it 'calculates sort key for a string' do
         mock(collator).get_collation_elements(string) { collation_elements }
-        collator.get_sort_key(string).should == sort_key
+        expect(collator.get_sort_key(string)).to eq(sort_key)
       end
 
       it 'calculates sort key for an array of code points (represented as hex strings)' do
         mock(collator).get_collation_elements(code_points) { collation_elements }
-        collator.get_sort_key(code_points).should == sort_key
+        expect(collator.get_sort_key(code_points)).to eq(sort_key)
       end
     end
 
@@ -135,7 +135,7 @@ describe Collator do
         mock(collator).get_collation_elements(code_points) { collation_elements }
         mock(TwitterCldr::Collation::SortKeyBuilder).build(collation_elements, :case_first => case_first, :maximum_level => nil) { sort_key }
 
-        collator.get_sort_key(code_points).should == sort_key
+        expect(collator.get_sort_key(code_points)).to eq(sort_key)
       end
 
       it 'passes maximum_level option to sort key builder' do 
@@ -147,7 +147,7 @@ describe Collator do
         mock(collator).get_collation_elements(code_points) { collation_elements }
         mock(TwitterCldr::Collation::SortKeyBuilder).build(collation_elements, :case_first => case_first, :maximum_level => maximum_level) { sort_key }
 
-        collator.get_sort_key(code_points, :maximum_level => maximum_level).should == sort_key
+        expect(collator.get_sort_key(code_points, :maximum_level => maximum_level)).to eq(sort_key)
       end
 
     end
@@ -164,14 +164,14 @@ describe Collator do
       stub_sort_key(collator, 'foo', sort_key)
       stub_sort_key(collator, 'bar', another_sort_key)
 
-      collator.compare('foo', 'bar').should == -1
-      collator.compare('bar', 'foo').should == 1
+      expect(collator.compare('foo', 'bar')).to eq(-1)
+      expect(collator.compare('bar', 'foo')).to eq(1)
     end
 
     it 'returns 0 without computing sort keys if the strings are equal' do
       dont_allow(collator).get_sort_key
 
-      collator.compare('foo', 'foo').should == 0
+      expect(collator.compare('foo', 'foo')).to eq(0)
     end
   end
 
@@ -188,18 +188,18 @@ describe Collator do
 
     describe '#sort' do
       it 'sorts strings by sort keys' do
-        collator.sort(array).should == sorted
+        expect(collator.sort(array)).to eq(sorted)
       end
 
       it 'does not change the original array' do
-        lambda { collator.sort(array) }.should_not change { array }
+        expect { collator.sort(array) }.not_to change { array }
       end
     end
 
     describe '#sort!' do
       it 'sorts strings array by sort keys in-place ' do
         collator.sort!(array)
-        array.should == sorted
+        expect(array).to eq(sorted)
       end
     end
   end
@@ -224,28 +224,28 @@ describe Collator do
 
     describe 'tailoring rules support' do
       it 'tailored collation elements are used' do
-        default_collator.get_collation_elements([0x490]).should  == [[0x5C1A, 5, 0x93], [0, 0xDBB9, 9]]
-        tailored_collator.get_collation_elements([0x490]).should == [[0x5C1B, 5, 0x86]]
+        expect(default_collator.get_collation_elements([0x490])).to  eq([[0x5C1A, 5, 0x93], [0, 0xDBB9, 9]])
+        expect(tailored_collator.get_collation_elements([0x490])).to eq([[0x5C1B, 5, 0x86]])
 
-        default_collator.get_collation_elements([0x491]).should  == [[0x5C1A, 5, 9], [0, 0xDBB9, 9]]
-        tailored_collator.get_collation_elements([0x491]).should == [[0x5C1B, 5, 5]]
+        expect(default_collator.get_collation_elements([0x491])).to  eq([[0x5C1A, 5, 9], [0, 0xDBB9, 9]])
+        expect(tailored_collator.get_collation_elements([0x491])).to eq([[0x5C1B, 5, 5]])
       end
 
       it 'original contractions for tailored elements are applied' do
-        default_collator.get_collation_elements([0x491, 0x306]).should  == [[0x5C, 0xDB, 9]]
-        tailored_collator.get_collation_elements([0x491, 0x306]).should == [[0x5C, 0xDB, 9]]
+        expect(default_collator.get_collation_elements([0x491, 0x306])).to  eq([[0x5C, 0xDB, 9]])
+        expect(tailored_collator.get_collation_elements([0x491, 0x306])).to eq([[0x5C, 0xDB, 9]])
       end
     end
 
     describe 'contractions suppressing support' do
       it 'suppressed contractions are ignored' do
-        default_collator.get_collation_elements([0x41A, 0x301]).should  == [[0x5CCC, 5, 0x8F]]
-        tailored_collator.get_collation_elements([0x41A, 0x301]).should == [[0x5C6C, 5, 0x8F], [0, 0x8D, 5]]
+        expect(default_collator.get_collation_elements([0x41A, 0x301])).to  eq([[0x5CCC, 5, 0x8F]])
+        expect(tailored_collator.get_collation_elements([0x41A, 0x301])).to eq([[0x5C6C, 5, 0x8F], [0, 0x8D, 5]])
       end
 
       it 'non-suppressed contractions are used' do
-        default_collator.get_collation_elements([0x415, 0x306]).should  == [[0x5C36, 5, 0x8F]]
-        tailored_collator.get_collation_elements([0x415, 0x306]).should == [[0x5C36, 5, 0x8F]]
+        expect(default_collator.get_collation_elements([0x415, 0x306])).to  eq([[0x5C36, 5, 0x8F]])
+        expect(tailored_collator.get_collation_elements([0x415, 0x306])).to eq([[0x5C36, 5, 0x8F]])
       end
     end
 

--- a/spec/collation/implicit_collation_elements_spec.rb
+++ b/spec/collation/implicit_collation_elements_spec.rb
@@ -10,15 +10,15 @@ include TwitterCldr::Collation
 describe ImplicitCollationElements do
 
   it 'computes correct implicit value for non-CJK code points' do
-    ImplicitCollationElements.for_code_point(0xD801).should  == [[0xE305C758, 0x5, 0x5]]
-    ImplicitCollationElements.for_code_point(0xC0001).should == [[0xE44E70AC, 0x5, 0x5]]
-    ImplicitCollationElements.for_code_point(0xFFF02).should == [[0xE4C25F74, 0x5, 0x5]]
+    expect(ImplicitCollationElements.for_code_point(0xD801)).to  eq([[0xE305C758, 0x5, 0x5]])
+    expect(ImplicitCollationElements.for_code_point(0xC0001)).to eq([[0xE44E70AC, 0x5, 0x5]])
+    expect(ImplicitCollationElements.for_code_point(0xFFF02)).to eq([[0xE4C25F74, 0x5, 0x5]])
   end
 
   it 'computes correct implicit values for CJK code points' do
-    ImplicitCollationElements.for_code_point(0x4E00).should  == [[0xE00406, 0x5, 0x5]]
-    ImplicitCollationElements.for_code_point(0x3400).should  == [[0xE0ABCE, 0x5, 0x5]]
-    ImplicitCollationElements.for_code_point(0x20000).should == [[0xE1302590, 0x5, 0x5]]
+    expect(ImplicitCollationElements.for_code_point(0x4E00)).to  eq([[0xE00406, 0x5, 0x5]])
+    expect(ImplicitCollationElements.for_code_point(0x3400)).to  eq([[0xE0ABCE, 0x5, 0x5]])
+    expect(ImplicitCollationElements.for_code_point(0x20000)).to eq([[0xE1302590, 0x5, 0x5]])
   end
 
 end

--- a/spec/collation/sort_key_builder_spec.rb
+++ b/spec/collation/sort_key_builder_spec.rb
@@ -20,37 +20,37 @@ describe SortKeyBuilder do
       mock(SortKeyBuilder).new(collation_elements, nil) { sort_key }
       mock(sort_key).bytes_array { sort_key_bytes }
 
-      SortKeyBuilder.build(collation_elements).should == sort_key_bytes
+      expect(SortKeyBuilder.build(collation_elements)).to eq(sort_key_bytes)
     end
   end
 
   describe '#initialize' do
     it 'assigns collation elements array' do
-      SortKeyBuilder.new(collation_elements).collation_elements.should == collation_elements
+      expect(SortKeyBuilder.new(collation_elements).collation_elements).to eq(collation_elements)
     end
 
     it 'accepts case-first option as an option' do
       SortKeyBuilder::VALID_CASE_FIRST_OPTIONS.each do |case_first|
-        lambda { SortKeyBuilder.new([], :case_first => case_first) }.should_not raise_error
+        expect { SortKeyBuilder.new([], :case_first => case_first) }.not_to raise_error
       end
     end
 
     it 'raises an ArgumentError for invalid case-first option' do
-      lambda { SortKeyBuilder.new([], :case_first => :wat) }.should raise_error(ArgumentError)
+      expect { SortKeyBuilder.new([], :case_first => :wat) }.to raise_error(ArgumentError)
     end
 
     it 'raises an ArgumentError for an invalid maximum_level option' do
-      lambda { SortKeyBuilder.new([], :maximum_level => :wat) }.should raise_error(ArgumentError)
+      expect { SortKeyBuilder.new([], :maximum_level => :wat) }.to raise_error(ArgumentError)
     end
 
     it 'raises an ArgumentError for non-hash second argument' do
-      lambda { SortKeyBuilder.new([], :upper) }.should raise_error(ArgumentError)
+      expect { SortKeyBuilder.new([], :upper) }.to raise_error(ArgumentError)
     end
   end
 
   describe '#bytes_array' do
     it 'builds sort key bytes' do
-      sort_key.bytes_array.should == sort_key_bytes
+      expect(sort_key.bytes_array).to eq(sort_key_bytes)
     end
 
     it 'builds bytes array only once' do
@@ -60,80 +60,82 @@ describe SortKeyBuilder do
 
     describe 'primary weights' do
       it 'compresses primary weights' do
-        SortKeyBuilder.new([[0x7A72,     0, 0], [0x7A73, 0, 0], [0x7A75, 0, 0], [0x908, 0, 0], [0x7A73, 0, 0]]).bytes_array.should ==
+        expect(SortKeyBuilder.new([[0x7A72,     0, 0], [0x7A73, 0, 0], [0x7A75, 0, 0], [0x908, 0, 0], [0x7A73, 0, 0]]).bytes_array).to eq(
                             [0x7A, 0x72,           0x73,           0x75, 0x3,    0x9, 0x08,     0x7A, 0x73, 1, 1]
+        )
 
-        SortKeyBuilder.new([[0x7A72,     0, 0], [0x7A73, 0, 0], [0x7A75, 0, 0], [0x9508, 0, 0], [0x7A73, 0, 0]]).bytes_array.should ==
+        expect(SortKeyBuilder.new([[0x7A72,     0, 0], [0x7A73, 0, 0], [0x7A75, 0, 0], [0x9508, 0, 0], [0x7A73, 0, 0]]).bytes_array).to eq(
                             [0x7A, 0x72,           0x73,           0x75, 0xFF,   0x95, 0x08,     0x7A, 0x73, 1, 1]
+        )
       end
 
       it 'works when there is an ignorable primary weight in the middle' do
-        SortKeyBuilder.new([[0x1312, 0, 0], [0, 0, 0], [0x1415, 0, 0]]).bytes_array.should == [0x13, 0x12, 0x14, 0x15, 1, 1]
+        expect(SortKeyBuilder.new([[0x1312, 0, 0], [0, 0, 0], [0x1415, 0, 0]]).bytes_array).to eq([0x13, 0x12, 0x14, 0x15, 1, 1])
       end
 
       it 'do not compress single byte primary weights' do
-        SortKeyBuilder.new([[0x13, 0, 0], [0x13, 0, 0]]).bytes_array.should == [0x13, 0x13, 1, 1]
+        expect(SortKeyBuilder.new([[0x13, 0, 0], [0x13, 0, 0]]).bytes_array).to eq([0x13, 0x13, 1, 1])
       end
 
       it 'resets primary lead bytes counter after a single byte weight' do
-        SortKeyBuilder.new([[0x1415, 0, 0], [0x13, 0, 0], [0x13, 0, 0], [0x1412, 0, 0]]).bytes_array.should == [0x14, 0x15, 0x13, 0x13, 0x14, 0x12, 1, 1]
+        expect(SortKeyBuilder.new([[0x1415, 0, 0], [0x13, 0, 0], [0x13, 0, 0], [0x1412, 0, 0]]).bytes_array).to eq([0x14, 0x15, 0x13, 0x13, 0x14, 0x12, 1, 1])
       end
 
       it 'compresses only compressible primary weights' do
-        SortKeyBuilder.new([[0x812, 0, 0], [0x811, 0, 0]]).bytes_array.should == [0x8, 0x12, 0x8, 0x11, 1, 1]
+        expect(SortKeyBuilder.new([[0x812, 0, 0], [0x811, 0, 0]]).bytes_array).to eq([0x8, 0x12, 0x8, 0x11, 1, 1])
       end
     end
 
     describe 'secondary weights' do
       it 'compresses secondary weights' do
-        SortKeyBuilder.new([[0, 5, 0], [0, 5, 0], [0, 141, 0], [0, 5, 0], [0, 5, 0]]).bytes_array.should == [1, 133, 141, 6, 1]
+        expect(SortKeyBuilder.new([[0, 5, 0], [0, 5, 0], [0, 141, 0], [0, 5, 0], [0, 5, 0]]).bytes_array).to eq([1, 133, 141, 6, 1])
       end
 
       it 'compresses secondary weights into multiple bytes if necessary' do
-        SortKeyBuilder.new([[0, 5, 0]] * 100).bytes_array.should == [1, 69, 40, 1]
+        expect(SortKeyBuilder.new([[0, 5, 0]] * 100).bytes_array).to eq([1, 69, 40, 1])
       end
     end
 
     describe 'tertiary weights' do
       context 'when case_first is not set' do
         it 'removes case bits and adds top addition to bytes that are greater than common' do
-          SortKeyBuilder.new([[0, 0, 9], [0, 0, 73], [0, 0, 137], [0, 0, 201]]).bytes_array.should == [1, 1, 137, 137, 137, 137]
+          expect(SortKeyBuilder.new([[0, 0, 9], [0, 0, 73], [0, 0, 137], [0, 0, 201]]).bytes_array).to eq([1, 1, 137, 137, 137, 137])
         end
 
         it 'compresses tertiary weights' do
-          SortKeyBuilder.new([[0, 0, 5], [0, 0, 5], [0, 0, 39], [0, 0, 5], [0, 0, 5]]).bytes_array.should == [1, 1, 0x84, 0xA7, 6]
+          expect(SortKeyBuilder.new([[0, 0, 5], [0, 0, 5], [0, 0, 39], [0, 0, 5], [0, 0, 5]]).bytes_array).to eq([1, 1, 0x84, 0xA7, 6])
         end
 
         it 'compresses tertiary weights into multiple bytes if necessary' do
-          SortKeyBuilder.new([[0, 0, 5]] * 100).bytes_array.should == [1, 1, 0x30, 0x30, 0x12]
+          expect(SortKeyBuilder.new([[0, 0, 5]] * 100).bytes_array).to eq([1, 1, 0x30, 0x30, 0x12])
         end
       end
 
       context 'when case_first is :upper' do
         it 'inverts case bits and subtract bottom addition from bytes that are smaller than common' do
-          SortKeyBuilder.new([[0, 0, 9], [0, 0, 80], [0, 0, 143]], :case_first => :upper).bytes_array.should == [1, 1, 201, 80, 15]
+          expect(SortKeyBuilder.new([[0, 0, 9], [0, 0, 80], [0, 0, 143]], :case_first => :upper).bytes_array).to eq([1, 1, 201, 80, 15])
         end
 
         it 'compresses tertiary weights' do
-          SortKeyBuilder.new([[0, 0, 5], [0, 0, 5], [0, 0, 39], [0, 0, 5], [0, 0, 5]], :case_first => :upper).bytes_array.should == [1, 1, 0xC4, 0xE7, 0xC3]
+          expect(SortKeyBuilder.new([[0, 0, 5], [0, 0, 5], [0, 0, 39], [0, 0, 5], [0, 0, 5]], :case_first => :upper).bytes_array).to eq([1, 1, 0xC4, 0xE7, 0xC3])
         end
 
         it 'compresses tertiary weights into multiple bytes if necessary' do
-          SortKeyBuilder.new([[0, 0, 5]] * 100, :case_first => :upper).bytes_array.should == [1, 1, 0x9C, 0x9C, 0xB3]
+          expect(SortKeyBuilder.new([[0, 0, 5]] * 100, :case_first => :upper).bytes_array).to eq([1, 1, 0x9C, 0x9C, 0xB3])
         end
       end
 
       context 'when case_first is :lower' do
         it 'leaves case bits and adds top addition to bytes that are greater than common' do
-          SortKeyBuilder.new([[0, 0, 9], [0, 0, 80], [0, 0, 143]], :case_first => :lower).bytes_array.should == [1, 1, 73, 144, 207]
+          expect(SortKeyBuilder.new([[0, 0, 9], [0, 0, 80], [0, 0, 143]], :case_first => :lower).bytes_array).to eq([1, 1, 73, 144, 207])
         end
 
         it 'compresses tertiary weights' do
-          SortKeyBuilder.new([[0, 0, 5], [0, 0, 5], [0, 0, 39], [0, 0, 5], [0, 0, 5]], :case_first => :lower).bytes_array.should == [1, 1, 0x44, 0x67, 6]
+          expect(SortKeyBuilder.new([[0, 0, 5], [0, 0, 5], [0, 0, 39], [0, 0, 5], [0, 0, 5]], :case_first => :lower).bytes_array).to eq([1, 1, 0x44, 0x67, 6])
         end
 
         it 'compresses tertiary weights into multiple bytes if necessary' do
-          SortKeyBuilder.new([[0, 0, 5]] * 100, :case_first => :lower).bytes_array.should == [1, 1, 0x1A, 0x1A, 0x1A, 0x1A, 0x14]
+          expect(SortKeyBuilder.new([[0, 0, 5]] * 100, :case_first => :lower).bytes_array).to eq([1, 1, 0x1A, 0x1A, 0x1A, 0x1A, 0x14])
         end
       end
     end
@@ -141,12 +143,12 @@ describe SortKeyBuilder do
     describe ":maximum_level option" do
       context "when :maximum_level is 2" do
         it 'does not include tertiary weights' do
-          SortKeyBuilder.new([[63, 13, 149], [66, 81, 143]], :maximum_level => 2).bytes_array.should == [63, 66, 1, 13, 81]
+          expect(SortKeyBuilder.new([[63, 13, 149], [66, 81, 143]], :maximum_level => 2).bytes_array).to eq([63, 66, 1, 13, 81])
         end
       end
       context "when :maximum_level is 1" do
         it 'only includes primary weights' do
-          SortKeyBuilder.new([[63, 13, 149], [66, 81, 143]], :maximum_level => 1).bytes_array.should == [63, 66]
+          expect(SortKeyBuilder.new([[63, 13, 149], [66, 81, 143]], :maximum_level => 1).bytes_array).to eq([63, 66])
         end
       end
     end

--- a/spec/collation/tailoring_spec.rb
+++ b/spec/collation/tailoring_spec.rb
@@ -49,7 +49,7 @@ describe 'Unicode collation tailoring' do
         else
           failures_info = "#{failures.size} failures: #{failures.inspect}"
           puts failures_info
-          failures.should(be_empty, "#{locale} - #{failures_info}")
+          expect(failures).to(be_empty, "#{locale} - #{failures_info}")
         end
       end
     end

--- a/spec/collation/trie_builder_spec.rb
+++ b/spec/collation/trie_builder_spec.rb
@@ -15,12 +15,12 @@ describe TrieBuilder do
     before(:each) { mock_default_table }
 
     it 'returns a Trie' do
-      trie.should be_instance_of(Trie)
+      expect(trie).to be_instance_of(Trie)
     end
 
     it 'adds every collation element from the fractional collation elements table to the trie' do
       collation_elements_table.each do |code_points, collation_elements|
-        trie.get(code_points).should == collation_elements
+        expect(trie.get(code_points)).to eq(collation_elements)
       end
     end
 
@@ -124,34 +124,34 @@ END
     end
 
     it 'returns a TrieWithFallback' do
-      tailored_trie.should be_instance_of(TrieWithFallback)
+      expect(tailored_trie).to be_instance_of(TrieWithFallback)
     end
 
     it 'tailors elements in the trie' do
-      fallback.get([0x0491]).should == [[0x5C1A, 5, 9], [0, 0xDBB9, 9]]
-      fallback.get([0x0490]).should == [[0x5C1A, 5, 0x93], [0, 0xDBB9, 9]]
+      expect(fallback.get([0x0491])).to eq([[0x5C1A, 5, 9], [0, 0xDBB9, 9]])
+      expect(fallback.get([0x0490])).to eq([[0x5C1A, 5, 0x93], [0, 0xDBB9, 9]])
 
-      tailored_trie.get([0x0491]).should == [[0x5C1B, 5, 5]]
-      tailored_trie.get([0x0490]).should == [[0x5C1B, 5, 0x86]]
+      expect(tailored_trie.get([0x0491])).to eq([[0x5C1B, 5, 5]])
+      expect(tailored_trie.get([0x0490])).to eq([[0x5C1B, 5, 0x86]])
     end
 
     it 'makes contractions available in the tailored trie' do
-      tailored_trie.get([0x491, 0x306]).should == [[0x5C, 0xDB, 9]]
-      tailored_trie.get([0x415, 0x306]).should == [[0x5C36, 5, 0x8F]]
+      expect(tailored_trie.get([0x491, 0x306])).to eq([[0x5C, 0xDB, 9]])
+      expect(tailored_trie.get([0x415, 0x306])).to eq([[0x5C36, 5, 0x8F]])
     end
 
     it 'suppresses required contractions' do
-      fallback.find_prefix([0x41A, 0x301]).first(2).should == [[[0x5CCC, 5, 0x8F]], 2]
-      fallback.find_prefix([0x413, 0x301]).first(2).should == [[[0x5C30, 5, 0x8F]], 2]
+      expect(fallback.find_prefix([0x41A, 0x301]).first(2)).to eq([[[0x5CCC, 5, 0x8F]], 2])
+      expect(fallback.find_prefix([0x413, 0x301]).first(2)).to eq([[[0x5C30, 5, 0x8F]], 2])
 
-      tailored_trie.find_prefix([0x41A, 0x301]).first(2).should == [[[0x5C6C, 5, 0x8F]], 1]
-      tailored_trie.find_prefix([0x413, 0x301]).first(2).should == [[[0x5C1A, 5, 0x8F]], 1]
+      expect(tailored_trie.find_prefix([0x41A, 0x301]).first(2)).to eq([[[0x5C6C, 5, 0x8F]], 1])
+      expect(tailored_trie.find_prefix([0x413, 0x301]).first(2)).to eq([[[0x5C1A, 5, 0x8F]], 1])
     end
 
     it 'do not copy other collation elements from the fallback' do
       [0x301, 0x306, 0x41A, 0x413, 0x415].each_slice(1) do |code_points|
-        tailored_trie.get(code_points).should_not be_nil
-        tailored_trie.get(code_points).object_id.should == fallback.get(code_points).object_id
+        expect(tailored_trie.get(code_points)).not_to be_nil
+        expect(tailored_trie.get(code_points).object_id).to eq(fallback.get(code_points).object_id)
       end
     end
 
@@ -187,7 +187,7 @@ END
 
     it 'loads tailoring data' do
       mock(TwitterCldr).get_resource(:collation, :tailoring, locale) { tailoring_data }
-      TrieBuilder.tailoring_data(locale).should == tailoring_data
+      expect(TrieBuilder.tailoring_data(locale)).to eq(tailoring_data)
     end
   end
 

--- a/spec/collation/trie_dumps_spec.rb
+++ b/spec/collation/trie_dumps_spec.rb
@@ -12,7 +12,7 @@ describe 'trie dumps', :slow => true do
   let(:error_message) { 'expected trie dump to be up-to-date.' }
 
   it 'has a valid default Fractional Collation Elements trie dump' do
-    TrieLoader.load_default_trie.to_hash.should(eq(default_trie.to_hash), error_message)
+    expect(TrieLoader.load_default_trie.to_hash).to(eq(default_trie.to_hash), error_message)
   end
 
   TwitterCldr.supported_locales.each do |locale|
@@ -20,7 +20,7 @@ describe 'trie dumps', :slow => true do
       loaded_trie = TrieLoader.load_tailored_trie(locale, Trie.new)
       fresh_trie  = TrieBuilder.load_tailored_trie(locale, default_trie)
 
-      loaded_trie.to_hash.should(eq(fresh_trie.to_hash), error_message)
+      expect(loaded_trie.to_hash).to(eq(fresh_trie.to_hash), error_message)
     end
   end
 end

--- a/spec/collation/trie_loader_spec.rb
+++ b/spec/collation/trie_loader_spec.rb
@@ -19,15 +19,15 @@ describe TrieLoader do
     before(:each) { mock_trie_dump }
 
     it 'loads a Trie' do
-      loaded_trie.should be_instance_of(Trie)
+      expect(loaded_trie).to be_instance_of(Trie)
     end
 
     it 'loads trie root' do
-      loaded_trie.instance_variable_get(:@root).should == root
+      expect(loaded_trie.instance_variable_get(:@root)).to eq(root)
     end
 
     it 'loads trie as unlocked' do
-      loaded_trie.should_not be_locked
+      expect(loaded_trie).not_to be_locked
     end
   end
 
@@ -43,25 +43,25 @@ describe TrieLoader do
     before(:each) { mock_trie_dump }
 
     it 'loads a TrieWithFallback' do
-      loaded_trie.should be_instance_of(TrieWithFallback)
+      expect(loaded_trie).to be_instance_of(TrieWithFallback)
     end
 
     it 'loads trie root' do
-      loaded_trie.instance_variable_get(:@root).should == root
+      expect(loaded_trie.instance_variable_get(:@root)).to eq(root)
     end
 
     it 'loads trie as unlocked' do
-      loaded_trie.should_not be_locked
+      expect(loaded_trie).not_to be_locked
     end
 
     it 'sets trie fallback' do
-      loaded_trie.fallback.should == new_fallback
+      expect(loaded_trie.fallback).to eq(new_fallback)
     end
   end
 
   describe '.dump_path' do
     it 'returns path to a trie dump for a specific locale' do
-      TrieLoader.dump_path(:foo).should == File.join(TwitterCldr::RESOURCES_DIR, 'collation', 'tries', 'foo.dump')
+      expect(TrieLoader.dump_path(:foo)).to eq(File.join(TwitterCldr::RESOURCES_DIR, 'collation', 'tries', 'foo.dump'))
     end
   end
 

--- a/spec/collation/trie_spec.rb
+++ b/spec/collation/trie_spec.rb
@@ -28,37 +28,37 @@ describe Trie do
 
   describe '#initialize' do
     it 'initializes an empty trie by default' do
-      Trie.new.should be_empty
+      expect(Trie.new).to be_empty
     end
 
     it 'initializes with a root node' do
       trie = Trie.new(Trie::Node.new(nil, 1 => Trie::Node.new(nil, { 2 => Trie::Node.new('12')}), 2 => Trie::Node.new('2')))
 
-      trie.to_hash.should == {
+      expect(trie.to_hash).to eq({
           1 => [nil, { 2 => ['12', {}] }],
           2 => ['2', {}]
-      }
+      })
     end
   end
 
   describe '#lock and #locked?' do
     it 'trie is unlocked by default' do
-      trie.should_not be_locked
+      expect(trie).not_to be_locked
     end
 
     it '#lock locks the trie' do
       trie.lock
-      trie.should be_locked
+      expect(trie).to be_locked
     end
 
     it '#lock returns the trie' do
-      trie.lock.should == trie
+      expect(trie.lock).to eq(trie)
     end
   end
 
   describe '#starters' do
     it 'returns all unique first elements of the keys in the trie' do
-      trie.starters.should =~ [1, 2, 3, 4]
+      expect(trie.starters).to match_array([1, 2, 3, 4])
     end
   end
 
@@ -67,64 +67,64 @@ describe Trie do
       res = {}
       trie.each_starting_with(1) { |k, v| res[k] = v }
 
-      res.should == { [1] => '1', [1, 4] => '14', [1, 5] => '15', [1, 4, 8] => '148' }
+      expect(res).to eq({ [1] => '1', [1, 4] => '14', [1, 5] => '15', [1, 4, 8] => '148' })
     end
 
     it 'works when argument is not a starter' do
       res = {}
       trie.each_starting_with(42) { |k, v| res[k] = v }
 
-      res.should == {}
+      expect(res).to eq({})
     end
   end
 
   describe '#get' do
     it 'returns nil for non existing keys' do
-      [[6], [3], [1, 4, 3], [2, 7, 5, 6, 9]].each { |key| trie.get(key).should be_nil }
+      [[6], [3], [1, 4, 3], [2, 7, 5, 6, 9]].each { |key| expect(trie.get(key)).to be_nil }
     end
 
     it 'returns value for each existing key' do
-      values.each { |key, value| trie.get(key).should == value }
+      values.each { |key, value| expect(trie.get(key)).to eq(value) }
     end
   end
 
   describe '#add' do
     it 'does not override values' do
-      trie.get([1, 4]).should == '14'
+      expect(trie.get([1, 4])).to eq('14')
 
       trie.add([1, 4], '14-new')
-      trie.get([1, 4]).should == '14'
+      expect(trie.get([1, 4])).to eq('14')
     end
 
     it 'adds new values' do
-      trie.get([1, 9]).should be_nil
+      expect(trie.get([1, 9])).to be_nil
 
       trie.add([1, 9], '19')
-      trie.get([1, 9]).should == '19'
+      expect(trie.get([1, 9])).to eq('19')
     end
 
     it 'raises RuntimeError if called on a locked trie' do
-      lambda { trie.lock.add([1, 3], 'value') }.should raise_error(RuntimeError)
+      expect { trie.lock.add([1, 3], 'value') }.to raise_error(RuntimeError)
     end
   end
 
   describe '#set' do
     it 'overrides values' do
-      trie.get([1, 4]).should == '14'
+      expect(trie.get([1, 4])).to eq('14')
 
       trie.set([1, 4], '14-new')
-      trie.get([1, 4]).should == '14-new'
+      expect(trie.get([1, 4])).to eq('14-new')
     end
 
     it 'adds new values' do
-      trie.get([1, 9]).should be_nil
+      expect(trie.get([1, 9])).to be_nil
 
       trie.set([1, 9], '19')
-      trie.get([1, 9]).should == '19'
+      expect(trie.get([1, 9])).to eq('19')
     end
 
     it 'raises RuntimeError if called on a locked trie' do
-      lambda { trie.lock.set([1, 3], 'value') }.should raise_error(RuntimeError)
+      expect { trie.lock.set([1, 3], 'value') }.to raise_error(RuntimeError)
     end
   end
 
@@ -140,12 +140,12 @@ describe Trie do
 
     describe 'first two elements of the returned array (value and prefix size)' do
       it 'are nil and 0 if the prefix was not found' do
-        trie.find_prefix([42]).first(2).should == [nil, 0]
+        expect(trie.find_prefix([42]).first(2)).to eq([nil, 0])
       end
 
       it 'are the stored value and the key size if the whole key was found' do
         values.each do |key, value|
-          trie.find_prefix(key).first(2).should == [value, key.size]
+          expect(trie.find_prefix(key).first(2)).to eq([value, key.size])
         end
       end
 
@@ -158,12 +158,12 @@ describe Trie do
         }
 
         tests.each do |key, result|
-          trie.find_prefix(key).first(2).should == result
+          expect(trie.find_prefix(key).first(2)).to eq(result)
         end
       end
 
       def test_find_prefix(trie, key, value, size = key.size)
-        trie.find_prefix(key).first(2).should == [value, size]
+        expect(trie.find_prefix(key).first(2)).to eq([value, size])
       end
     end
 
@@ -175,23 +175,23 @@ describe Trie do
       it 'is always a locked trie' do
         [trie, trie.lock].each do |some_trie|
           [non_existing_key, key_with_suffixes, key_without_suffixes].each do |key|
-            some_trie.find_prefix(key).last.should be_locked
+            expect(some_trie.find_prefix(key).last).to be_locked
           end
         end
       end
 
       it 'is a locked empty subtrie if the prefix that was found does not have any suffixes' do
-        trie.find_prefix(key_without_suffixes).last.to_hash.should be_empty
+        expect(trie.find_prefix(key_without_suffixes).last.to_hash).to be_empty
       end
 
       it 'is a subtrie of possible suffixes for the prefix that was found' do
-        trie.find_prefix(key_with_suffixes).last.to_hash.should == { 7 => [nil, { 5 => ["275", {}] }] }
+        expect(trie.find_prefix(key_with_suffixes).last.to_hash).to eq({ 7 => [nil, { 5 => ["275", {}] }] })
       end
 
       it 'is a hash representing the whole trie if the prefix was not found' do
-        trie.get(non_existing_key).should be_nil
+        expect(trie.get(non_existing_key)).to be_nil
 
-        trie.find_prefix(non_existing_key).last.to_hash.should == root_subtrie
+        expect(trie.find_prefix(non_existing_key).last.to_hash).to eq(root_subtrie)
       end
 
     end
@@ -199,26 +199,26 @@ describe Trie do
     context 'argument does not match any value, but is a prefix of a longer key' do
       context 'argument has a shorter key as a prefix' do
         it 'returns value for the key, its size and suffixes subtrie' do
-          trie.get([2]).should_not be_nil
-          trie.get([2, 7, 5]).should_not be_nil
+          expect(trie.get([2])).not_to be_nil
+          expect(trie.get([2, 7, 5])).not_to be_nil
 
           result = trie.find_prefix([2, 7])
 
-          result.first(2).should == ['2', 1]
-          result.last.to_hash.should == { 7 => [nil, { 5 => ["275", {}] }] }
+          expect(result.first(2)).to eq(['2', 1])
+          expect(result.last.to_hash).to eq({ 7 => [nil, { 5 => ["275", {}] }] })
         end
       end
 
       context 'argument does not have a shorter key as a prefix' do
         it 'returns nil, 0 and suffixes subtrie for the root node' do
-          trie.get([3]).should be_nil
-          trie.get([3, 9]).should be_nil
-          trie.get([3, 9, 2]).should_not be_nil
+          expect(trie.get([3])).to be_nil
+          expect(trie.get([3, 9])).to be_nil
+          expect(trie.get([3, 9, 2])).not_to be_nil
 
           result = trie.find_prefix([3, 9])
 
-          result.first(2).should == [nil, 0]
-          result.last.to_hash.should == root_subtrie
+          expect(result.first(2)).to eq([nil, 0])
+          expect(result.last.to_hash).to eq(root_subtrie)
         end
       end
     end
@@ -231,11 +231,11 @@ describe Trie do
       trie.add([13, 37], 1337)
       trie.add([42], 42)
 
-      Marshal.load(Marshal.dump(trie)).to_hash.should == { 42 => [42, {}], 13 => [nil, { 37 => [1337, {}] }] }
+      expect(Marshal.load(Marshal.dump(trie)).to_hash).to eq({ 42 => [42, {}], 13 => [nil, { 37 => [1337, {}] }] })
     end
 
     it 'does not dump locked state' do
-      Marshal.load(Marshal.dump(Trie.new.lock)).should_not be_locked
+      expect(Marshal.load(Marshal.dump(Trie.new.lock))).not_to be_locked
     end
   end
 
@@ -288,36 +288,36 @@ describe Trie do
 
     describe '#initialize' do
       it 'initializes node with nil value and empty children hash by default' do
-        node.value.should be_nil
-        node.should_not have_children
+        expect(node.value).to be_nil
+        expect(node).not_to have_children
       end
 
       it 'initializes node with provided value and children hash' do
-        root_node.value.should == 'node-0'
-        root_node.should have_children
+        expect(root_node.value).to eq('node-0')
+        expect(root_node).to have_children
       end
     end
 
     describe '#child and #set_child' do
       it '#child returns nil if a child with a given key does not exist' do
-        node.child(42).should be_nil
+        expect(node.child(42)).to be_nil
       end
 
       it '#set_child saves a child by key and #child returns the child by key' do
         node.set_child(42, child)
-        node.child(42).should == child
+        expect(node.child(42)).to eq(child)
       end
 
       it '#set_child overrides a child by key' do
         node.set_child(42, child)
         node.set_child(42, another_child)
 
-        node.child(42).should_not == child
-        node.child(42).should == another_child
+        expect(node.child(42)).not_to eq(child)
+        expect(node.child(42)).to eq(another_child)
       end
 
       it '#set_child returns the child that was saved' do
-        node.set_child(42, child).should == child
+        expect(node.set_child(42, child)).to eq(child)
       end
     end
 
@@ -328,7 +328,7 @@ describe Trie do
         res = {}
         node.each_key_and_child { |key, child| res[key] = child }
 
-        res.should == { 42 => child, 13 => another_child }
+        expect(res).to eq({ 42 => child, 13 => another_child })
       end
     end
 
@@ -337,47 +337,47 @@ describe Trie do
         node.set_child(42, child)
         node.set_child(13, another_child)
 
-        node.keys.should =~ [13, 42]
+        expect(node.keys).to match_array([13, 42])
       end
     end
 
     describe '#has_children?' do
       it 'returns false if the node has no children' do
-        node.should_not have_children
+        expect(node).not_to have_children
       end
 
       it 'returns true if the node has children' do
         node.set_child(42, child)
-        node.should have_children
+        expect(node).to have_children
       end
     end
 
     describe '#to_trie' do
       it 'returns a trie' do
-        node.to_trie.should be_instance_of(Trie)
+        expect(node.to_trie).to be_instance_of(Trie)
       end
 
       it 'returns a locked trie' do
-        node.to_trie.should be_locked
+        expect(node.to_trie).to be_locked
       end
 
       it 'current node is a root of a new trie' do
-        root_node.to_trie.to_hash.should == subtrie_hash
+        expect(root_node.to_trie.to_hash).to eq(subtrie_hash)
       end
 
       it 'sets new trie root value to nil' do
-        root_node.value.should_not be_nil
-        root_node.to_trie.instance_variable_get(:@root).value.should be_nil
+        expect(root_node.value).not_to be_nil
+        expect(root_node.to_trie.instance_variable_get(:@root).value).to be_nil
       end
     end
 
     describe '#subtrie_hash' do
       it 'returns an empty hash if the node has no children' do
-        node.subtrie_hash.should == {}
+        expect(node.subtrie_hash).to eq({})
       end
 
       it 'returns a nested hash of children values' do
-        root_node.subtrie_hash.should == subtrie_hash
+        expect(root_node.subtrie_hash).to eq(subtrie_hash)
       end
     end
 

--- a/spec/collation/trie_with_fallback_spec.rb
+++ b/spec/collation/trie_with_fallback_spec.rb
@@ -17,30 +17,30 @@ describe TrieWithFallback do
   describe '#get' do
     it 'returns result if the key is present' do
       dont_allow(fallback).get
-      trie.get([1, 2, 3]).should == 'value'
+      expect(trie.get([1, 2, 3])).to eq('value')
     end
 
     it 'resorts to the fallback if the key is not present' do
       mock(fallback).get([3, 2, 1]) { 'fallback-value' }
-      trie.get([3, 2, 1]).should == 'fallback-value'
+      expect(trie.get([3, 2, 1])).to eq('fallback-value')
     end
   end
 
   describe '#find_prefix' do
     it 'returns result if the key is present' do
       dont_allow(fallback).find_prefix
-      trie.find_prefix([1, 2, 3, 4]).first(2).should == ['value', 3]
+      expect(trie.find_prefix([1, 2, 3, 4]).first(2)).to eq(['value', 3])
     end
 
     it 'resorts to the fallback if the key is not present' do
       mock(fallback).find_prefix([3, 2, 1]) { 'fallback-result' }
-      trie.find_prefix([3, 2, 1]).should == 'fallback-result'
+      expect(trie.find_prefix([3, 2, 1])).to eq('fallback-result')
     end
   end
 
   describe 'marshaling' do
     it 'does not dump fallback' do
-      Marshal.load(Marshal.dump(TrieWithFallback.new(Trie.new))).fallback.should be_nil
+      expect(Marshal.load(Marshal.dump(TrieWithFallback.new(Trie.new))).fallback).to be_nil
     end
   end
 

--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -11,7 +11,7 @@ describe 'Core classes localization' do
     describe klass do
       it 'has public instance method #localize' do
         # convert methods names to symbols (they're strings in 1.8)
-        klass.public_instance_methods.map(&:to_sym).should include(:localize)
+        expect(klass.public_instance_methods.map(&:to_sym)).to include(:localize)
       end
     end
   end

--- a/spec/data_readers/additional_date_format_selector_spec.rb
+++ b/spec/data_readers/additional_date_format_selector_spec.rb
@@ -18,13 +18,13 @@ describe AdditionalDateFormatSelector do
     it "calculates the score based on relative offset from actual position" do
       goal_entities = selector.send(:separate, "MMMyyd")
       entities      = selector.send(:separate, "d")
-      selector.send(:position_score, entities, goal_entities).should == 2
+      expect(selector.send(:position_score, entities, goal_entities)).to eq(2)
     end
 
     it "calculates a zero score if all entites are in the same positions" do
       goal_entities = selector.send(:separate, "MMMyyd")
       entities      = selector.send(:separate, "MMMyyd")
-      selector.send(:position_score, entities, goal_entities).should == 0
+      expect(selector.send(:position_score, entities, goal_entities)).to eq(0)
     end
   end
 
@@ -32,13 +32,13 @@ describe AdditionalDateFormatSelector do
     it "calculates a higher score if an entity doesn't exist" do
       goal_entities = selector.send(:separate, "MMMEd")
       entities      = selector.send(:separate, "d")
-      selector.send(:exist_score, entities, goal_entities).should == 2
+      expect(selector.send(:exist_score, entities, goal_entities)).to eq(2)
     end
 
     it "calculates a zero score if all entities exist" do
       goal_entities = selector.send(:separate, "MMMyyd")
       entities      = selector.send(:separate, "dMMMyy")
-      selector.send(:exist_score, entities, goal_entities).should == 0
+      expect(selector.send(:exist_score, entities, goal_entities)).to eq(0)
     end
   end
 
@@ -46,13 +46,13 @@ describe AdditionalDateFormatSelector do
     it "calculates the score based on the difference in the length of each matching entity" do
       goal_entities = selector.send(:separate, "MMMyyd")
       entities      = selector.send(:separate, "ddMMy")
-      selector.send(:count_score, entities, goal_entities).should == 3
+      expect(selector.send(:count_score, entities, goal_entities)).to eq(3)
     end
 
     it "calculates a zero score if all entities are the same length" do
       goal_entities = selector.send(:separate, "MMMyyd")
       entities      = selector.send(:separate, "d")
-      selector.send(:count_score, entities, goal_entities).should == 0
+      expect(selector.send(:count_score, entities, goal_entities)).to eq(0)
     end
   end
 
@@ -60,72 +60,72 @@ describe AdditionalDateFormatSelector do
     it "calculates a cumulative score from position and count" do
       goal_entities = selector.send(:separate, "MMMyydGG")
       entities      = selector.send(:separate, "ddMMGGyy")
-      selector.send(:exist_score, entities, goal_entities).should == 0
-      selector.send(:count_score, entities, goal_entities).should == 2
-      selector.send(:position_score, entities, goal_entities).should == 3
-      selector.send(:score, entities, goal_entities).should == 5
+      expect(selector.send(:exist_score, entities, goal_entities)).to eq(0)
+      expect(selector.send(:count_score, entities, goal_entities)).to eq(2)
+      expect(selector.send(:position_score, entities, goal_entities)).to eq(3)
+      expect(selector.send(:score, entities, goal_entities)).to eq(5)
     end
 
     it "calculates a cumulative score from position, count, and existence (existence weighted by 2)" do
       goal_entities = selector.send(:separate, "MMMyydGG")
       entities      = selector.send(:separate, "ddMMyy")
-      selector.send(:exist_score, entities, goal_entities).should == 1
-      selector.send(:count_score, entities, goal_entities).should == 2
-      selector.send(:position_score, entities, goal_entities).should == 1
+      expect(selector.send(:exist_score, entities, goal_entities)).to eq(1)
+      expect(selector.send(:count_score, entities, goal_entities)).to eq(2)
+      expect(selector.send(:position_score, entities, goal_entities)).to eq(1)
       # (exist_score * 2) + count_score + position_score
-      selector.send(:score, entities, goal_entities).should == 5
+      expect(selector.send(:score, entities, goal_entities)).to eq(5)
     end
   end
 
   describe "#rank" do
     it "returns a score for each available format" do
       ranked_formats = selector.send(:rank, "MMMd")
-      ranked_formats["MMMd"].should == 0
-      ranked_formats["yMEd"].should == 4
-      ranked_formats["y"].should == 4
-      ranked_formats["EHms"].should == 4
-      ranked_formats["MMM"].should == 2
+      expect(ranked_formats["MMMd"]).to eq(0)
+      expect(ranked_formats["yMEd"]).to eq(4)
+      expect(ranked_formats["y"]).to eq(4)
+      expect(ranked_formats["EHms"]).to eq(4)
+      expect(ranked_formats["MMM"]).to eq(2)
     end
   end
 
   describe "#find_closest" do
     it "returns an exact match if it exists" do
-      selector.find_closest("h").should == selector.pattern_hash[:h]
-      selector.find_closest("MMMd").should == selector.pattern_hash[:MMMd]
-      selector.find_closest("Hms").should == selector.pattern_hash[:Hms]
-      selector.find_closest("yQQQQ").should == selector.pattern_hash[:yQQQQ]
+      expect(selector.find_closest("h")).to eq(selector.pattern_hash[:h])
+      expect(selector.find_closest("MMMd")).to eq(selector.pattern_hash[:MMMd])
+      expect(selector.find_closest("Hms")).to eq(selector.pattern_hash[:Hms])
+      expect(selector.find_closest("yQQQQ")).to eq(selector.pattern_hash[:yQQQQ])
     end
 
     it "returns the next closest match (lowest score) if an exact match can't be found" do
-      selector.find_closest("MMMMd").should == selector.pattern_hash[:MMMd]
-      selector.find_closest("mHs").should == selector.pattern_hash[:Hms]
-      selector.find_closest("Med").should == selector.pattern_hash[:MEd]
+      expect(selector.find_closest("MMMMd")).to eq(selector.pattern_hash[:MMMd])
+      expect(selector.find_closest("mHs")).to eq(selector.pattern_hash[:Hms])
+      expect(selector.find_closest("Med")).to eq(selector.pattern_hash[:MEd])
     end
 
     it "returns nil if an empty pattern is given" do
-      selector.find_closest(nil).should be_nil
-      selector.find_closest("").should be_nil
-      selector.find_closest(" ").should be_nil
+      expect(selector.find_closest(nil)).to be_nil
+      expect(selector.find_closest("")).to be_nil
+      expect(selector.find_closest(" ")).to be_nil
     end
   end
 
   describe "#separate" do
     it "divides a string into entities by runs of equal characters" do
-      selector.send(:separate, "ddMMyy").should == ["dd", "MM", "yy"]
-      selector.send(:separate, "ddMMyyMM").should == ["dd", "MM", "yy", "MM"]
-      selector.send(:separate, "mmMM").should == ["mm", "MM"]
+      expect(selector.send(:separate, "ddMMyy")).to eq(["dd", "MM", "yy"])
+      expect(selector.send(:separate, "ddMMyyMM")).to eq(["dd", "MM", "yy", "MM"])
+      expect(selector.send(:separate, "mmMM")).to eq(["mm", "MM"])
     end
   end
 
   describe "#patterns" do
     it "returns a list of all available patterns" do
       patterns = selector.patterns
-      patterns.should be_a(Array)
-      patterns.should include("MMMd")
-      patterns.should include("yQQQ")
-      patterns.should include("yQQQQ")
-      patterns.should include("EHms")
-      patterns.should include("d")
+      expect(patterns).to be_a(Array)
+      expect(patterns).to include("MMMd")
+      expect(patterns).to include("yQQQ")
+      expect(patterns).to include("yQQQQ")
+      expect(patterns).to include("EHms")
+      expect(patterns).to include("d")
     end
   end
 

--- a/spec/data_readers/date_time_data_reader_spec.rb
+++ b/spec/data_readers/date_time_data_reader_spec.rb
@@ -12,8 +12,8 @@ describe DateTimeDataReader do
 
   describe "#initialize" do
     it "chooses gregorian as the calendar type if none is specified" do
-      DateTimeDataReader.new(:es).calendar_type.should == :gregorian
-      DateTimeDataReader.new(:es, :calendar_type => :julian).calendar_type.should == :julian
+      expect(DateTimeDataReader.new(:es).calendar_type).to eq(:gregorian)
+      expect(DateTimeDataReader.new(:es, :calendar_type => :julian).calendar_type).to eq(:julian)
     end
   end
 

--- a/spec/data_readers/number_data_reader_spec.rb
+++ b/spec/data_readers/number_data_reader_spec.rb
@@ -12,7 +12,7 @@ describe NumberDataReader do
 
   describe "#get_key_for" do
     it "builds a power-of-ten key based on the number of digits in the input" do
-      (3..15).each { |i| data_reader.send(:get_key_for, "1337#{"0" * (i - 3)}").should == 10 ** i }
+      (3..15).each { |i| expect(data_reader.send(:get_key_for, "1337#{"0" * (i - 3)}")).to eq(10 ** i) }
     end
   end
 end

--- a/spec/formatters/calendars/datetime_formatter_spec.rb
+++ b/spec/formatters/calendars/datetime_formatter_spec.rb
@@ -15,381 +15,381 @@ describe DateTimeFormatter do
 
   describe "#day" do
     it "test: pattern d" do
-      @formatter.send(:day, Date.new(2010, 1,  1), 'd', 1).should == '1'
-      @formatter.send(:day, Date.new(2010, 1, 10), 'd', 1).should == '10'
+      expect(@formatter.send(:day, Date.new(2010, 1,  1), 'd', 1)).to eq('1')
+      expect(@formatter.send(:day, Date.new(2010, 1, 10), 'd', 1)).to eq('10')
     end
 
     it "test: pattern dd" do
-      @formatter.send(:day, Date.new(2010, 1,  1), 'dd', 2).should == '01'
-      @formatter.send(:day, Date.new(2010, 1, 10), 'dd', 2).should == '10'
+      expect(@formatter.send(:day, Date.new(2010, 1,  1), 'dd', 2)).to eq('01')
+      expect(@formatter.send(:day, Date.new(2010, 1, 10), 'dd', 2)).to eq('10')
     end
   end
 
   describe "#weekday_local_stand_alone" do
     it "test: pattern c" do
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   4), 'c', 1).should == '1'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   5), 'c', 1).should == '2'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,  10), 'c', 1).should == '7'
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   4), 'c', 1)).to eq('1')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   5), 'c', 1)).to eq('2')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,  10), 'c', 1)).to eq('7')
     end
 
     it "test: pattern cc" do
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 4),  'cc',  2).should == 'Mo.'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 5),  'cc',  2).should == 'Di.'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 10), 'cc',  2).should == 'So.'
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 4),  'cc',  2)).to eq('Mo.')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 5),  'cc',  2)).to eq('Di.')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 10), 'cc',  2)).to eq('So.')
     end
 
     it "test: pattern ccc" do
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 4),  'ccc',  3).should == 'Mo.'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 5),  'ccc',  3).should == 'Di.'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 10), 'ccc',  3).should == 'So.'
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 4),  'ccc',  3)).to eq('Mo.')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 5),  'ccc',  3)).to eq('Di.')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1, 10), 'ccc',  3)).to eq('So.')
     end
 
     it "test: pattern cccc" do
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   4), 'cccc', 4).should == 'Montag'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   5), 'cccc', 4).should == 'Dienstag'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,  10), 'cccc', 4).should == 'Sonntag'
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   4), 'cccc', 4)).to eq('Montag')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   5), 'cccc', 4)).to eq('Dienstag')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,  10), 'cccc', 4)).to eq('Sonntag')
     end
 
     it "test: pattern ccccc" do
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   4), 'ccccc', 5).should == 'M'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   5), 'ccccc', 5).should == 'D'
-      @formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,  10), 'ccccc', 5).should == 'S'
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   4), 'ccccc', 5)).to eq('M')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,   5), 'ccccc', 5)).to eq('D')
+      expect(@formatter.send(:weekday_local_stand_alone, Date.new(2010, 1,  10), 'ccccc', 5)).to eq('S')
     end
   end
 
   describe "#weekday_local" do
     it "test: pattern e" do
-      @formatter.send(:weekday_local, Date.new(2010, 1,   4), 'e', 1).should == '1'
-      @formatter.send(:weekday_local, Date.new(2010, 1,   5), 'e', 1).should == '2'
-      @formatter.send(:weekday_local, Date.new(2010, 1,  10), 'e', 1).should == '7'
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   4), 'e', 1)).to eq('1')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   5), 'e', 1)).to eq('2')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,  10), 'e', 1)).to eq('7')
     end
 
     it "test: pattern ee" do
-      @formatter.send(:weekday_local, Date.new(2010, 1,   4), 'ee', 2).should == '1'
-      @formatter.send(:weekday_local, Date.new(2010, 1,   5), 'ee', 2).should == '2'
-      @formatter.send(:weekday_local, Date.new(2010, 1,  10), 'ee', 2).should == '7'
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   4), 'ee', 2)).to eq('1')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   5), 'ee', 2)).to eq('2')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,  10), 'ee', 2)).to eq('7')
     end
 
     it "test: pattern eee" do
-      @formatter.send(:weekday_local, Date.new(2010, 1,   4), 'eee', 3).should == 'Mo.'
-      @formatter.send(:weekday_local, Date.new(2010, 1,   5), 'eee', 3).should == 'Di.'
-      @formatter.send(:weekday_local, Date.new(2010, 1,  10), 'eee', 3).should == 'So.'
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   4), 'eee', 3)).to eq('Mo.')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   5), 'eee', 3)).to eq('Di.')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,  10), 'eee', 3)).to eq('So.')
     end
 
     it "test: pattern eeee" do
-      @formatter.send(:weekday_local, Date.new(2010, 1,   4), 'eeee', 4).should == 'Montag'
-      @formatter.send(:weekday_local, Date.new(2010, 1,   5), 'eeee', 4).should == 'Dienstag'
-      @formatter.send(:weekday_local, Date.new(2010, 1,  10), 'eeee', 4).should == 'Sonntag'
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   4), 'eeee', 4)).to eq('Montag')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   5), 'eeee', 4)).to eq('Dienstag')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,  10), 'eeee', 4)).to eq('Sonntag')
     end
 
     it "test: pattern eeeee" do
-      @formatter.send(:weekday_local, Date.new(2010, 1,   4), 'eeeee', 5).should == 'M'
-      @formatter.send(:weekday_local, Date.new(2010, 1,   5), 'eeeee', 5).should == 'D'
-      @formatter.send(:weekday_local, Date.new(2010, 1,  10), 'eeeee', 5).should == 'S'
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   4), 'eeeee', 5)).to eq('M')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,   5), 'eeeee', 5)).to eq('D')
+      expect(@formatter.send(:weekday_local, Date.new(2010, 1,  10), 'eeeee', 5)).to eq('S')
     end
   end
 
   describe "#weekday" do
     it "test: pattern E, EE, EEE" do
-      @formatter.send(:weekday, Date.new(2010, 1, 1), 'E',   1).should == 'Fr.'
-      @formatter.send(:weekday, Date.new(2010, 1, 1), 'EE',  2).should == 'Fr.'
-      @formatter.send(:weekday, Date.new(2010, 1, 1), 'EEE', 3).should == 'Fr.'
+      expect(@formatter.send(:weekday, Date.new(2010, 1, 1), 'E',   1)).to eq('Fr.')
+      expect(@formatter.send(:weekday, Date.new(2010, 1, 1), 'EE',  2)).to eq('Fr.')
+      expect(@formatter.send(:weekday, Date.new(2010, 1, 1), 'EEE', 3)).to eq('Fr.')
     end
 
     it "test: pattern EEEE" do
-      @formatter.send(:weekday, Date.new(2010, 1, 1), 'EEEE', 4).should == 'Freitag'
+      expect(@formatter.send(:weekday, Date.new(2010, 1, 1), 'EEEE', 4)).to eq('Freitag')
     end
 
     it "test: pattern EEEEE" do
-      @formatter.send(:weekday, Date.new(2010, 1, 1), 'EEEEE', 5).should == 'F'
+      expect(@formatter.send(:weekday, Date.new(2010, 1, 1), 'EEEEE', 5)).to eq('F')
     end
   end
 
   describe "#hour" do
     it "test: h" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'h', 1).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'h', 1).should == '1'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'h', 1).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'h', 1).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'h', 1).should == '11'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'h', 1)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'h', 1)).to eq('1')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'h', 1)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'h', 1)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'h', 1)).to eq('11')
     end
 
     it "test: hh" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'hh', 2).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'hh', 2).should == '01'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'hh', 2).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'hh', 2).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'hh', 2).should == '11'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'hh', 2)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'hh', 2)).to eq('01')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'hh', 2)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'hh', 2)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'hh', 2)).to eq('11')
     end
 
     it "test: H" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'H', 1).should == '0'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'H', 1).should == '1'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'H', 1).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'H', 1).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'H', 1).should == '23'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'H', 1)).to eq('0')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'H', 1)).to eq('1')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'H', 1)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'H', 1)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'H', 1)).to eq('23')
     end
 
     it "test: HH" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'HH', 2).should == '00'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'HH', 2).should == '01'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'HH', 2).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'HH', 2).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'HH', 2).should == '23'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'HH', 2)).to eq('00')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'HH', 2)).to eq('01')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'HH', 2)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'HH', 2)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'HH', 2)).to eq('23')
     end
 
     it "test: K" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'K', 1).should == '0'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'K', 1).should == '1'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'K', 1).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'K', 1).should == '0'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'K', 1).should == '11'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'K', 1)).to eq('0')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'K', 1)).to eq('1')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'K', 1)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'K', 1)).to eq('0')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'K', 1)).to eq('11')
     end
 
     it "test: KK" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'KK', 2).should == '00'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'KK', 2).should == '01'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'KK', 2).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'KK', 2).should == '00'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'KK', 2).should == '11'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'KK', 2)).to eq('00')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'KK', 2)).to eq('01')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'KK', 2)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'KK', 2)).to eq('00')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'KK', 2)).to eq('11')
     end
 
     it "test: k" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'k', 1).should == '24'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'k', 1).should == '1'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'k', 1).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'k', 1).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'k', 1).should == '23'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'k', 1)).to eq('24')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'k', 1)).to eq('1')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'k', 1)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'k', 1)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'k', 1)).to eq('23')
     end
 
     it "test: kk" do
-      @formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'kk', 2).should == '24'
-      @formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'kk', 2).should == '01'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'kk', 2).should == '11'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'kk', 2).should == '12'
-      @formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'kk', 2).should == '23'
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  0, 1, 1), 'kk', 2)).to eq('24')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1,  1, 1, 1), 'kk', 2)).to eq('01')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 11, 1, 1), 'kk', 2)).to eq('11')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 12, 1, 1), 'kk', 2)).to eq('12')
+      expect(@formatter.send(:hour, Time.local(2000, 1, 1, 23, 1, 1), 'kk', 2)).to eq('23')
     end
   end
 
   describe "#minute" do
     it "test: m" do
-      @formatter.send(:minute, Time.local(2000, 1, 1, 1,  1, 1), 'm', 1).should == '1'
-      @formatter.send(:minute, Time.local(2000, 1, 1, 1, 11, 1), 'm', 1).should == '11'
+      expect(@formatter.send(:minute, Time.local(2000, 1, 1, 1,  1, 1), 'm', 1)).to eq('1')
+      expect(@formatter.send(:minute, Time.local(2000, 1, 1, 1, 11, 1), 'm', 1)).to eq('11')
     end
 
     it "test: mm" do
-      @formatter.send(:minute, Time.local(2000, 1, 1, 1,  1, 1), 'mm', 2).should == '01'
-      @formatter.send(:minute, Time.local(2000, 1, 1, 1, 11, 1), 'mm', 2).should == '11'
+      expect(@formatter.send(:minute, Time.local(2000, 1, 1, 1,  1, 1), 'mm', 2)).to eq('01')
+      expect(@formatter.send(:minute, Time.local(2000, 1, 1, 1, 11, 1), 'mm', 2)).to eq('11')
     end
   end
 
   describe "#month" do
     it "test: pattern M" do
-      @formatter.send(:month, Date.new(2010,  1, 1), 'M', 1).should == '1'
-      @formatter.send(:month, Date.new(2010, 10, 1), 'M', 1).should == '10'
+      expect(@formatter.send(:month, Date.new(2010,  1, 1), 'M', 1)).to eq('1')
+      expect(@formatter.send(:month, Date.new(2010, 10, 1), 'M', 1)).to eq('10')
     end
 
     it "test: pattern MM" do
-      @formatter.send(:month, Date.new(2010,  1, 1), 'MM', 2).should == '01'
-      @formatter.send(:month, Date.new(2010, 10, 1), 'MM', 2).should == '10'
+      expect(@formatter.send(:month, Date.new(2010,  1, 1), 'MM', 2)).to eq('01')
+      expect(@formatter.send(:month, Date.new(2010, 10, 1), 'MM', 2)).to eq('10')
     end
 
     it "test: pattern MMM" do
-      @formatter.send(:month, Date.new(2010,  1, 1), 'MMM', 3).should == 'Jan.'
-      @formatter.send(:month, Date.new(2010, 10, 1), 'MMM', 3).should == 'Okt.'
+      expect(@formatter.send(:month, Date.new(2010,  1, 1), 'MMM', 3)).to eq('Jan.')
+      expect(@formatter.send(:month, Date.new(2010, 10, 1), 'MMM', 3)).to eq('Okt.')
     end
 
     it "test: pattern MMMM" do
-      @formatter.send(:month, Date.new(2010,  1, 1), 'MMMM', 4).should == 'Januar'
-      @formatter.send(:month, Date.new(2010, 10, 1), 'MMMM', 4).should == 'Oktober'
+      expect(@formatter.send(:month, Date.new(2010,  1, 1), 'MMMM', 4)).to eq('Januar')
+      expect(@formatter.send(:month, Date.new(2010, 10, 1), 'MMMM', 4)).to eq('Oktober')
     end
 
     it "test: pattern L" do
-      @formatter.send(:month, Date.new(2010,  1, 1), 'L', 1).should == '1'
-      @formatter.send(:month, Date.new(2010, 10, 1), 'L', 1).should == '10'
+      expect(@formatter.send(:month, Date.new(2010,  1, 1), 'L', 1)).to eq('1')
+      expect(@formatter.send(:month, Date.new(2010, 10, 1), 'L', 1)).to eq('10')
     end
 
     it "test: pattern LL" do
-      @formatter.send(:month, Date.new(2010,  1, 1), 'LL', 2).should == '01'
-      @formatter.send(:month, Date.new(2010, 10, 1), 'LL', 2).should == '10'
+      expect(@formatter.send(:month, Date.new(2010,  1, 1), 'LL', 2)).to eq('01')
+      expect(@formatter.send(:month, Date.new(2010, 10, 1), 'LL', 2)).to eq('10')
     end
   end
 
   describe "#period" do
     it "test: a" do
-      @formatter.send(:period, Time.local(2000, 1, 1, 1, 1, 1), 'a', 1).should == 'vorm.'
-      @formatter.send(:period, Time.local(2000, 1, 1, 15, 1, 1), 'a', 1).should == 'nachm.'
+      expect(@formatter.send(:period, Time.local(2000, 1, 1, 1, 1, 1), 'a', 1)).to eq('vorm.')
+      expect(@formatter.send(:period, Time.local(2000, 1, 1, 15, 1, 1), 'a', 1)).to eq('nachm.')
     end
   end
 
   describe "#quarter" do
     it "test: pattern Q" do
-      @formatter.send(:quarter, Date.new(2010, 1,  1),  'Q', 1).should == '1'
-      @formatter.send(:quarter, Date.new(2010, 3, 31),  'Q', 1).should == '1'
-      @formatter.send(:quarter, Date.new(2010, 4,  1),  'Q', 1).should == '2'
-      @formatter.send(:quarter, Date.new(2010, 6, 30),  'Q', 1).should == '2'
-      @formatter.send(:quarter, Date.new(2010, 7,  1),  'Q', 1).should == '3'
-      @formatter.send(:quarter, Date.new(2010, 9, 30),  'Q', 1).should == '3'
-      @formatter.send(:quarter, Date.new(2010, 10,  1), 'Q', 1).should == '4'
-      @formatter.send(:quarter, Date.new(2010, 12, 31), 'Q', 1).should == '4'
+      expect(@formatter.send(:quarter, Date.new(2010, 1,  1),  'Q', 1)).to eq('1')
+      expect(@formatter.send(:quarter, Date.new(2010, 3, 31),  'Q', 1)).to eq('1')
+      expect(@formatter.send(:quarter, Date.new(2010, 4,  1),  'Q', 1)).to eq('2')
+      expect(@formatter.send(:quarter, Date.new(2010, 6, 30),  'Q', 1)).to eq('2')
+      expect(@formatter.send(:quarter, Date.new(2010, 7,  1),  'Q', 1)).to eq('3')
+      expect(@formatter.send(:quarter, Date.new(2010, 9, 30),  'Q', 1)).to eq('3')
+      expect(@formatter.send(:quarter, Date.new(2010, 10,  1), 'Q', 1)).to eq('4')
+      expect(@formatter.send(:quarter, Date.new(2010, 12, 31), 'Q', 1)).to eq('4')
     end
 
     it "test: pattern QQ" do
-      @formatter.send(:quarter, Date.new(2010, 1,  1),  'QQ', 2).should == '01'
-      @formatter.send(:quarter, Date.new(2010, 3, 31),  'QQ', 2).should == '01'
-      @formatter.send(:quarter, Date.new(2010, 4,  1),  'QQ', 2).should == '02'
-      @formatter.send(:quarter, Date.new(2010, 6, 30),  'QQ', 2).should == '02'
-      @formatter.send(:quarter, Date.new(2010, 7,  1),  'QQ', 2).should == '03'
-      @formatter.send(:quarter, Date.new(2010, 9, 30),  'QQ', 2).should == '03'
-      @formatter.send(:quarter, Date.new(2010, 10,  1), 'QQ', 2).should == '04'
-      @formatter.send(:quarter, Date.new(2010, 12, 31), 'QQ', 2).should == '04'
+      expect(@formatter.send(:quarter, Date.new(2010, 1,  1),  'QQ', 2)).to eq('01')
+      expect(@formatter.send(:quarter, Date.new(2010, 3, 31),  'QQ', 2)).to eq('01')
+      expect(@formatter.send(:quarter, Date.new(2010, 4,  1),  'QQ', 2)).to eq('02')
+      expect(@formatter.send(:quarter, Date.new(2010, 6, 30),  'QQ', 2)).to eq('02')
+      expect(@formatter.send(:quarter, Date.new(2010, 7,  1),  'QQ', 2)).to eq('03')
+      expect(@formatter.send(:quarter, Date.new(2010, 9, 30),  'QQ', 2)).to eq('03')
+      expect(@formatter.send(:quarter, Date.new(2010, 10,  1), 'QQ', 2)).to eq('04')
+      expect(@formatter.send(:quarter, Date.new(2010, 12, 31), 'QQ', 2)).to eq('04')
     end
 
     it "test: pattern QQQ" do
-      @formatter.send(:quarter, Date.new(2010, 1,  1),  'QQQ', 3).should == 'Q1'
-      @formatter.send(:quarter, Date.new(2010, 3, 31),  'QQQ', 3).should == 'Q1'
-      @formatter.send(:quarter, Date.new(2010, 4,  1),  'QQQ', 3).should == 'Q2'
-      @formatter.send(:quarter, Date.new(2010, 6, 30),  'QQQ', 3).should == 'Q2'
-      @formatter.send(:quarter, Date.new(2010, 7,  1),  'QQQ', 3).should == 'Q3'
-      @formatter.send(:quarter, Date.new(2010, 9, 30),  'QQQ', 3).should == 'Q3'
-      @formatter.send(:quarter, Date.new(2010, 10,  1), 'QQQ', 3).should == 'Q4'
-      @formatter.send(:quarter, Date.new(2010, 12, 31), 'QQQ', 3).should == 'Q4'
+      expect(@formatter.send(:quarter, Date.new(2010, 1,  1),  'QQQ', 3)).to eq('Q1')
+      expect(@formatter.send(:quarter, Date.new(2010, 3, 31),  'QQQ', 3)).to eq('Q1')
+      expect(@formatter.send(:quarter, Date.new(2010, 4,  1),  'QQQ', 3)).to eq('Q2')
+      expect(@formatter.send(:quarter, Date.new(2010, 6, 30),  'QQQ', 3)).to eq('Q2')
+      expect(@formatter.send(:quarter, Date.new(2010, 7,  1),  'QQQ', 3)).to eq('Q3')
+      expect(@formatter.send(:quarter, Date.new(2010, 9, 30),  'QQQ', 3)).to eq('Q3')
+      expect(@formatter.send(:quarter, Date.new(2010, 10,  1), 'QQQ', 3)).to eq('Q4')
+      expect(@formatter.send(:quarter, Date.new(2010, 12, 31), 'QQQ', 3)).to eq('Q4')
     end
 
     it "test: pattern QQQQ" do
-      @formatter.send(:quarter, Date.new(2010, 1,  1),  'QQQQ', 4).should == '1. Quartal'
-      @formatter.send(:quarter, Date.new(2010, 3, 31),  'QQQQ', 4).should == '1. Quartal'
-      @formatter.send(:quarter, Date.new(2010, 4,  1),  'QQQQ', 4).should == '2. Quartal'
-      @formatter.send(:quarter, Date.new(2010, 6, 30),  'QQQQ', 4).should == '2. Quartal'
-      @formatter.send(:quarter, Date.new(2010, 7,  1),  'QQQQ', 4).should == '3. Quartal'
-      @formatter.send(:quarter, Date.new(2010, 9, 30),  'QQQQ', 4).should == '3. Quartal'
-      @formatter.send(:quarter, Date.new(2010, 10,  1), 'QQQQ', 4).should == '4. Quartal'
-      @formatter.send(:quarter, Date.new(2010, 12, 31), 'QQQQ', 4).should == '4. Quartal'
+      expect(@formatter.send(:quarter, Date.new(2010, 1,  1),  'QQQQ', 4)).to eq('1. Quartal')
+      expect(@formatter.send(:quarter, Date.new(2010, 3, 31),  'QQQQ', 4)).to eq('1. Quartal')
+      expect(@formatter.send(:quarter, Date.new(2010, 4,  1),  'QQQQ', 4)).to eq('2. Quartal')
+      expect(@formatter.send(:quarter, Date.new(2010, 6, 30),  'QQQQ', 4)).to eq('2. Quartal')
+      expect(@formatter.send(:quarter, Date.new(2010, 7,  1),  'QQQQ', 4)).to eq('3. Quartal')
+      expect(@formatter.send(:quarter, Date.new(2010, 9, 30),  'QQQQ', 4)).to eq('3. Quartal')
+      expect(@formatter.send(:quarter, Date.new(2010, 10,  1), 'QQQQ', 4)).to eq('4. Quartal')
+      expect(@formatter.send(:quarter, Date.new(2010, 12, 31), 'QQQQ', 4)).to eq('4. Quartal')
     end
 
     it "test: pattern q" do
-      @formatter.send(:quarter, Date.new(2010, 1,  1),  'q', 1).should == '1'
-      @formatter.send(:quarter, Date.new(2010, 3, 31),  'q', 1).should == '1'
-      @formatter.send(:quarter, Date.new(2010, 4,  1),  'q', 1).should == '2'
-      @formatter.send(:quarter, Date.new(2010, 6, 30),  'q', 1).should == '2'
-      @formatter.send(:quarter, Date.new(2010, 7,  1),  'q', 1).should == '3'
-      @formatter.send(:quarter, Date.new(2010, 9, 30),  'q', 1).should == '3'
-      @formatter.send(:quarter, Date.new(2010, 10,  1), 'q', 1).should == '4'
-      @formatter.send(:quarter, Date.new(2010, 12, 31), 'q', 1).should == '4'
+      expect(@formatter.send(:quarter, Date.new(2010, 1,  1),  'q', 1)).to eq('1')
+      expect(@formatter.send(:quarter, Date.new(2010, 3, 31),  'q', 1)).to eq('1')
+      expect(@formatter.send(:quarter, Date.new(2010, 4,  1),  'q', 1)).to eq('2')
+      expect(@formatter.send(:quarter, Date.new(2010, 6, 30),  'q', 1)).to eq('2')
+      expect(@formatter.send(:quarter, Date.new(2010, 7,  1),  'q', 1)).to eq('3')
+      expect(@formatter.send(:quarter, Date.new(2010, 9, 30),  'q', 1)).to eq('3')
+      expect(@formatter.send(:quarter, Date.new(2010, 10,  1), 'q', 1)).to eq('4')
+      expect(@formatter.send(:quarter, Date.new(2010, 12, 31), 'q', 1)).to eq('4')
     end
 
     it "test: pattern qq" do
-      @formatter.send(:quarter, Date.new(2010, 1,  1),  'qq', 2).should == '01'
-      @formatter.send(:quarter, Date.new(2010, 3, 31),  'qq', 2).should == '01'
-      @formatter.send(:quarter, Date.new(2010, 4,  1),  'qq', 2).should == '02'
-      @formatter.send(:quarter, Date.new(2010, 6, 30),  'qq', 2).should == '02'
-      @formatter.send(:quarter, Date.new(2010, 7,  1),  'qq', 2).should == '03'
-      @formatter.send(:quarter, Date.new(2010, 9, 30),  'qq', 2).should == '03'
-      @formatter.send(:quarter, Date.new(2010, 10,  1), 'qq', 2).should == '04'
-      @formatter.send(:quarter, Date.new(2010, 12, 31), 'qq', 2).should == '04'
+      expect(@formatter.send(:quarter, Date.new(2010, 1,  1),  'qq', 2)).to eq('01')
+      expect(@formatter.send(:quarter, Date.new(2010, 3, 31),  'qq', 2)).to eq('01')
+      expect(@formatter.send(:quarter, Date.new(2010, 4,  1),  'qq', 2)).to eq('02')
+      expect(@formatter.send(:quarter, Date.new(2010, 6, 30),  'qq', 2)).to eq('02')
+      expect(@formatter.send(:quarter, Date.new(2010, 7,  1),  'qq', 2)).to eq('03')
+      expect(@formatter.send(:quarter, Date.new(2010, 9, 30),  'qq', 2)).to eq('03')
+      expect(@formatter.send(:quarter, Date.new(2010, 10,  1), 'qq', 2)).to eq('04')
+      expect(@formatter.send(:quarter, Date.new(2010, 12, 31), 'qq', 2)).to eq('04')
     end
   end
 
   describe "#second" do
     it "test: s" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1,  1), 's', 1).should == '1'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 11), 's', 1).should == '11'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1,  1), 's', 1)).to eq('1')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 11), 's', 1)).to eq('11')
     end
 
     it "test: ss" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1,  1), 'ss', 2).should == '01'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 11), 'ss', 2).should == '11'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1,  1), 'ss', 2)).to eq('01')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 11), 'ss', 2)).to eq('11')
     end
 
     # have i gotten the spec right here?  (Sven Fuchs)
     it "test: S" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'S', 1).should == '0'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'S', 1).should == '1'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 18), 'S', 1).should == '18'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'S', 1)).to eq('0')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'S', 1)).to eq('1')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 18), 'S', 1)).to eq('18')
     end
 
     it "test: SS" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'SS', 2).should == '00'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SS', 2).should == '01'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SS', 2).should == '08'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SS', 2).should == '21'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'SS', 2)).to eq('00')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SS', 2)).to eq('01')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SS', 2)).to eq('08')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SS', 2)).to eq('21')
     end
 
     it "test: SSS" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'SSS', 3).should == '000'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSS', 3).should == '001'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSS', 3).should == '008'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSS', 3).should == '021'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'SSS', 3)).to eq('000')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSS', 3)).to eq('001')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSS', 3)).to eq('008')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSS', 3)).to eq('021')
     end
 
     it "test: SSSS" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'SSSS', 4).should == '0000'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSSS', 4).should == '0001'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSSS', 4).should == '0008'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSSS', 4).should == '0021'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 0), 'SSSS', 4)).to eq('0000')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSSS', 4)).to eq('0001')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSSS', 4)).to eq('0008')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSSS', 4)).to eq('0021')
     end
 
     it "test: SSSSS" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSSSS', 5).should == '00001'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSSSS', 5).should == '00008'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSSSS', 5).should == '00021'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSSSS', 5)).to eq('00001')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSSSS', 5)).to eq('00008')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSSSS', 5)).to eq('00021')
     end
 
     it "test: SSSSSS" do
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSSSSS', 6).should == '000001'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSSSSS', 6).should == '000008'
-      @formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSSSSS', 6).should == '000021'
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 1), 'SSSSSS', 6)).to eq('000001')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 8), 'SSSSSS', 6)).to eq('000008')
+      expect(@formatter.send(:second, Time.local(2000, 1, 1, 1, 1, 21), 'SSSSSS', 6)).to eq('000021')
     end
   end
 
   describe "#timezone" do
     it "test: z, zz, zzz" do # TODO is this what's meant by the spec?
-      @formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'z', 1).should == 'UTC'
-      @formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'zz', 2).should == 'UTC'
-      @formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'zzz', 3).should == 'UTC'
-      @formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'zzzz', 4).should =~ /^UTC (-|\+)\d{2}:\d{2}$/
+      expect(@formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'z', 1)).to eq('UTC')
+      expect(@formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'zz', 2)).to eq('UTC')
+      expect(@formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'zzz', 3)).to eq('UTC')
+      expect(@formatter.send(:timezone, Time.gm(2000, 1, 1, 1, 1, 1), 'zzzz', 4)).to match(/^UTC (-|\+)\d{2}:\d{2}$/)
     end
   end
 
   describe "#year" do
     it "test: pattern y" do
-      @formatter.send(:year, Date.new(    5, 1, 1), 'y', 1).should == '5'
-      @formatter.send(:year, Date.new(   45, 1, 1), 'y', 1).should == '45'
-      @formatter.send(:year, Date.new(  345, 1, 1), 'y', 1).should == '345'
-      @formatter.send(:year, Date.new( 2345, 1, 1), 'y', 1).should == '2345'
-      @formatter.send(:year, Date.new(12345, 1, 1), 'y', 1).should == '12345'
+      expect(@formatter.send(:year, Date.new(    5, 1, 1), 'y', 1)).to eq('5')
+      expect(@formatter.send(:year, Date.new(   45, 1, 1), 'y', 1)).to eq('45')
+      expect(@formatter.send(:year, Date.new(  345, 1, 1), 'y', 1)).to eq('345')
+      expect(@formatter.send(:year, Date.new( 2345, 1, 1), 'y', 1)).to eq('2345')
+      expect(@formatter.send(:year, Date.new(12345, 1, 1), 'y', 1)).to eq('12345')
     end
 
     it "test: pattern yy" do
-      @formatter.send(:year, Date.new(    5, 1, 1), 'yy', 2).should == '05'
-      @formatter.send(:year, Date.new(   45, 1, 1), 'yy', 2).should == '45'
-      @formatter.send(:year, Date.new(  345, 1, 1), 'yy', 2).should == '45'
-      @formatter.send(:year, Date.new( 2345, 1, 1), 'yy', 2).should == '45'
-      @formatter.send(:year, Date.new(12345, 1, 1), 'yy', 2).should == '45'
+      expect(@formatter.send(:year, Date.new(    5, 1, 1), 'yy', 2)).to eq('05')
+      expect(@formatter.send(:year, Date.new(   45, 1, 1), 'yy', 2)).to eq('45')
+      expect(@formatter.send(:year, Date.new(  345, 1, 1), 'yy', 2)).to eq('45')
+      expect(@formatter.send(:year, Date.new( 2345, 1, 1), 'yy', 2)).to eq('45')
+      expect(@formatter.send(:year, Date.new(12345, 1, 1), 'yy', 2)).to eq('45')
     end
 
     it "test: pattern yyy" do
-      @formatter.send(:year, Date.new(    5, 1, 1), 'yyy', 3).should == '005'
-      @formatter.send(:year, Date.new(   45, 1, 1), 'yyy', 3).should == '045'
-      @formatter.send(:year, Date.new(  345, 1, 1), 'yyy', 3).should == '345'
-      @formatter.send(:year, Date.new( 2345, 1, 1), 'yyy', 3).should == '2345'
-      @formatter.send(:year, Date.new(12345, 1, 1), 'yyy', 3).should == '12345'
+      expect(@formatter.send(:year, Date.new(    5, 1, 1), 'yyy', 3)).to eq('005')
+      expect(@formatter.send(:year, Date.new(   45, 1, 1), 'yyy', 3)).to eq('045')
+      expect(@formatter.send(:year, Date.new(  345, 1, 1), 'yyy', 3)).to eq('345')
+      expect(@formatter.send(:year, Date.new( 2345, 1, 1), 'yyy', 3)).to eq('2345')
+      expect(@formatter.send(:year, Date.new(12345, 1, 1), 'yyy', 3)).to eq('12345')
     end
 
     it "test: pattern yyyy" do
-      @formatter.send(:year, Date.new(    5, 1, 1), 'yyyy', 4).should == '0005'
-      @formatter.send(:year, Date.new(   45, 1, 1), 'yyyy', 4).should == '0045'
-      @formatter.send(:year, Date.new(  345, 1, 1), 'yyyy', 4).should == '0345'
-      @formatter.send(:year, Date.new( 2345, 1, 1), 'yyyy', 4).should == '2345'
-      @formatter.send(:year, Date.new(12345, 1, 1), 'yyyy', 4).should == '12345'
+      expect(@formatter.send(:year, Date.new(    5, 1, 1), 'yyyy', 4)).to eq('0005')
+      expect(@formatter.send(:year, Date.new(   45, 1, 1), 'yyyy', 4)).to eq('0045')
+      expect(@formatter.send(:year, Date.new(  345, 1, 1), 'yyyy', 4)).to eq('0345')
+      expect(@formatter.send(:year, Date.new( 2345, 1, 1), 'yyyy', 4)).to eq('2345')
+      expect(@formatter.send(:year, Date.new(12345, 1, 1), 'yyyy', 4)).to eq('12345')
     end
 
     it "test: pattern yyyyy" do
-      @formatter.send(:year, Date.new(    5, 1, 1), 'yyyyy', 5).should == '00005'
-      @formatter.send(:year, Date.new(   45, 1, 1), 'yyyyy', 5).should == '00045'
-      @formatter.send(:year, Date.new(  345, 1, 1), 'yyyyy', 5).should == '00345'
-      @formatter.send(:year, Date.new( 2345, 1, 1), 'yyyyy', 5).should == '02345'
-      @formatter.send(:year, Date.new(12345, 1, 1), 'yyyyy', 5).should == '12345'
+      expect(@formatter.send(:year, Date.new(    5, 1, 1), 'yyyyy', 5)).to eq('00005')
+      expect(@formatter.send(:year, Date.new(   45, 1, 1), 'yyyyy', 5)).to eq('00045')
+      expect(@formatter.send(:year, Date.new(  345, 1, 1), 'yyyyy', 5)).to eq('00345')
+      expect(@formatter.send(:year, Date.new( 2345, 1, 1), 'yyyyy', 5)).to eq('02345')
+      expect(@formatter.send(:year, Date.new(12345, 1, 1), 'yyyyy', 5)).to eq('12345')
     end
   end
 
@@ -400,23 +400,23 @@ describe DateTimeFormatter do
     end
 
     it "test: pattern G" do
-      @formatter.send(:era, Date.new(2012, 1, 1), 'G', 1).should == "CE"
-      @formatter.send(:era, Date.new(-1, 1, 1), 'G', 1).should == "BCE"
+      expect(@formatter.send(:era, Date.new(2012, 1, 1), 'G', 1)).to eq("CE")
+      expect(@formatter.send(:era, Date.new(-1, 1, 1), 'G', 1)).to eq("BCE")
     end
 
     it "test: pattern GG" do
-      @formatter.send(:era, Date.new(2012, 1, 1), 'GG', 2).should == "CE"
-      @formatter.send(:era, Date.new(-1, 1, 1), 'GG', 2).should == "BCE"
+      expect(@formatter.send(:era, Date.new(2012, 1, 1), 'GG', 2)).to eq("CE")
+      expect(@formatter.send(:era, Date.new(-1, 1, 1), 'GG', 2)).to eq("BCE")
     end
 
     it "test: pattern GGG" do
-      @formatter.send(:era, Date.new(2012, 1, 1), 'GGG', 3).should == "CE"
-      @formatter.send(:era, Date.new(-1, 1, 1), 'GGG', 3).should == "BCE"
+      expect(@formatter.send(:era, Date.new(2012, 1, 1), 'GGG', 3)).to eq("CE")
+      expect(@formatter.send(:era, Date.new(-1, 1, 1), 'GGG', 3)).to eq("BCE")
     end
 
     it "test: pattern GGGG" do
-      @formatter.send(:era, Date.new(2012, 1, 1), 'GGGG', 4).should == "Common Era"
-      @formatter.send(:era, Date.new(-1, 1, 1), 'GGGG', 4).should == "Before Common Era"
+      expect(@formatter.send(:era, Date.new(2012, 1, 1), 'GGGG', 4)).to eq("Common Era")
+      expect(@formatter.send(:era, Date.new(-1, 1, 1), 'GGGG', 4)).to eq("Before Common Era")
     end
 
     it "should fall back if the calendar doesn't contain the appropriate era data" do
@@ -431,34 +431,34 @@ describe DateTimeFormatter do
       date = Date.new(2012, 1, 1)
       mock.proxy(@formatter).era(date, "GGGG", 4)  # first attempts to find full name era
       mock.proxy(@formatter).era(date, "GGG", 3)   # falls back to abbreviated era
-      @formatter.send(:era, date, 'GGGG', 4).should == "abbr1"
+      expect(@formatter.send(:era, date, 'GGGG', 4)).to eq("abbr1")
     end
   end
 
   describe "#month_stand_alone" do
     it "pattern L" do
-      @formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'L', 1).should == "1"
-      @formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'L', 1).should == "10"
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'L', 1)).to eq("1")
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'L', 1)).to eq("10")
     end
 
     it "pattern LL" do
-      @formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LL', 2).should == "01"
-      @formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LL', 2).should == "10"
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LL', 2)).to eq("01")
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LL', 2)).to eq("10")
     end
 
     it "pattern LLL" do
-      @formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LLL', 3).should == "Jan"
-      @formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LLL', 3).should == "Okt"
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LLL', 3)).to eq("Jan")
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LLL', 3)).to eq("Okt")
     end
 
     it "pattern LLLL" do
-      @formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LLLL', 4).should == "Januar"
-      @formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LLLL', 4).should == "Oktober"
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LLLL', 4)).to eq("Januar")
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LLLL', 4)).to eq("Oktober")
     end
 
     it "pattern LLLLL" do
-      @formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LLLLL', 5).should == "J"
-      @formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LLLLL', 5).should == "O"
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  1,  1), 'LLLLL', 5)).to eq("J")
+      expect(@formatter.send(:month_stand_alone, Date.new(2010,  10, 1), 'LLLLL', 5)).to eq("O")
     end
   end
 end

--- a/spec/formatters/list_formatter_spec.rb
+++ b/spec/formatters/list_formatter_spec.rb
@@ -10,11 +10,11 @@ include TwitterCldr::Formatters
 describe ListFormatter do
   describe '#initialize' do
     it 'fetches locale from options hash' do
-      ListFormatter.new(:pt).locale.should == :pt
+      expect(ListFormatter.new(:pt).locale).to eq(:pt)
     end
 
     it "uses default locale if it's not passed in options hash" do
-      ListFormatter.new.locale.should == TwitterCldr.locale
+      expect(ListFormatter.new.locale).to eq(TwitterCldr.locale)
     end
   end
 
@@ -27,9 +27,9 @@ describe ListFormatter do
       end
 
       it "formats English lists correctly using various types" do
-        @formatter.format(list).should == "larry, curly, and moe"
-        @formatter.format(list, :unit).should == "larry, curly, moe"
-        @formatter.format(list, :"unit-narrow").should == "larry curly moe"
+        expect(@formatter.format(list)).to eq("larry, curly, and moe")
+        expect(@formatter.format(list, :unit)).to eq("larry, curly, moe")
+        expect(@formatter.format(list, :"unit-narrow")).to eq("larry curly moe")
       end
     end
 
@@ -39,9 +39,9 @@ describe ListFormatter do
       end
 
       it "formats Spanish lists correctly using various types" do
-        @formatter.format(list).should == "larry, curly y moe"
-        @formatter.format(list, :unit).should == "larry, curly y moe"
-        @formatter.format(list, :"unit-narrow").should == "larry curly moe"
+        expect(@formatter.format(list)).to eq("larry, curly y moe")
+        expect(@formatter.format(list, :unit)).to eq("larry, curly y moe")
+        expect(@formatter.format(list, :"unit-narrow")).to eq("larry curly moe")
       end
     end
   end

--- a/spec/formatters/numbers/abbreviated/abbreviated_number_formatter_spec.rb
+++ b/spec/formatters/numbers/abbreviated/abbreviated_number_formatter_spec.rb
@@ -12,26 +12,26 @@ describe AbbreviatedNumberFormatter do
 
   describe "#transform_number" do
     it "chops off the number to the necessary number of sig figs" do
-      formatter.send(:transform_number, 10 ** 3).should == 1
-      formatter.send(:transform_number, 10 ** 4).should == 10
-      formatter.send(:transform_number, 10 ** 5).should == 100
-      formatter.send(:transform_number, 10 ** 6).should == 1
-      formatter.send(:transform_number, 10 ** 7).should == 10
-      formatter.send(:transform_number, 10 ** 8).should == 100
-      formatter.send(:transform_number, 10 ** 9).should == 1
-      formatter.send(:transform_number, 10 ** 10).should == 10
-      formatter.send(:transform_number, 10 ** 11).should == 100
-      formatter.send(:transform_number, 10 ** 12).should == 1
-      formatter.send(:transform_number, 10 ** 13).should == 10
-      formatter.send(:transform_number, 10 ** 14).should == 100
+      expect(formatter.send(:transform_number, 10 ** 3)).to eq(1)
+      expect(formatter.send(:transform_number, 10 ** 4)).to eq(10)
+      expect(formatter.send(:transform_number, 10 ** 5)).to eq(100)
+      expect(formatter.send(:transform_number, 10 ** 6)).to eq(1)
+      expect(formatter.send(:transform_number, 10 ** 7)).to eq(10)
+      expect(formatter.send(:transform_number, 10 ** 8)).to eq(100)
+      expect(formatter.send(:transform_number, 10 ** 9)).to eq(1)
+      expect(formatter.send(:transform_number, 10 ** 10)).to eq(10)
+      expect(formatter.send(:transform_number, 10 ** 11)).to eq(100)
+      expect(formatter.send(:transform_number, 10 ** 12)).to eq(1)
+      expect(formatter.send(:transform_number, 10 ** 13)).to eq(10)
+      expect(formatter.send(:transform_number, 10 ** 14)).to eq(100)
     end
 
     it "returns the original number if greater than 10^15" do
-      formatter.send(:transform_number, 10 ** 15).should == 10 ** 15
+      expect(formatter.send(:transform_number, 10 ** 15)).to eq(10 ** 15)
     end
 
     it "returns the original number if less than 10^3" do
-      formatter.send(:transform_number, 999).should == 999
+      expect(formatter.send(:transform_number, 999)).to eq(999)
     end
   end
 end

--- a/spec/formatters/numbers/abbreviated/long_decimal_formatter_spec.rb
+++ b/spec/formatters/numbers/abbreviated/long_decimal_formatter_spec.rb
@@ -33,7 +33,7 @@ describe LongDecimalFormatter do
 
     expected.each do |num, text|
       pattern = data_reader.pattern(num)
-      formatter.format(tokenizer.tokenize(pattern), num).should == text
+      expect(formatter.format(tokenizer.tokenize(pattern), num)).to eq(text)
     end
   end
 
@@ -43,14 +43,14 @@ describe LongDecimalFormatter do
   end
 
   it "formats the number as if it were a straight decimal if it exceeds 10^15" do
-    format_number(10**15).should == "1,000,000,000,000,000"
+    expect(format_number(10**15)).to eq("1,000,000,000,000,000")
   end
 
   it "formats the number as if it were a straight decimal if it's less than 1000" do
-    format_number(500).should == "500"
+    expect(format_number(500)).to eq("500")
   end
 
   it "respects the :precision option" do
-    format_number(12345, :precision => 3).should match_normalized("12.345 thousand")
+    expect(format_number(12345, :precision => 3)).to match_normalized("12.345 thousand")
   end
 end

--- a/spec/formatters/numbers/abbreviated/short_decimal_formatter_spec.rb
+++ b/spec/formatters/numbers/abbreviated/short_decimal_formatter_spec.rb
@@ -33,25 +33,25 @@ describe ShortDecimalFormatter do
 
     expected.each do |num, text|
       pattern = data_reader.pattern(num)
-      formatter.format(tokenizer.tokenize(pattern), num).should == text
+      expect(formatter.format(tokenizer.tokenize(pattern), num)).to eq(text)
     end
   end
 
   it "formats the number as if it were a straight decimal if it exceeds 10^15" do
     number = 10**15
     pattern = data_reader.pattern(number)
-    formatter.format(tokenizer.tokenize(pattern), number).should == "1,000,000,000,000,000"
+    expect(formatter.format(tokenizer.tokenize(pattern), number)).to eq("1,000,000,000,000,000")
   end
 
   it "formats the number as if it were a straight decimal if it's less than 1000" do
     number = 500
     pattern = data_reader.pattern(number)
-    formatter.format(tokenizer.tokenize(pattern), number).should == "500"
+    expect(formatter.format(tokenizer.tokenize(pattern), number)).to eq("500")
   end
 
   it "respects the :precision option" do
     number = 12345
     pattern = data_reader.pattern(number)
-    formatter.format(tokenizer.tokenize(pattern), number, :precision => 3).should match_normalized("12.345K")
+    expect(formatter.format(tokenizer.tokenize(pattern), number, :precision => 3)).to match_normalized("12.345K")
   end
 end

--- a/spec/formatters/numbers/currency_formatter_spec.rb
+++ b/spec/formatters/numbers/currency_formatter_spec.rb
@@ -19,45 +19,45 @@ describe CurrencyFormatter do
     end
 
     it "should use a dollar sign when no other currency symbol is given (and default to a precision of 2)" do
-      format_currency(12).should == "$12.00"
+      expect(format_currency(12)).to eq("$12.00")
     end
 
     it "handles negative numbers" do
       # yes, the parentheses really are part of the format, don't worry about it
-      format_currency(-12).should == "($12.00)"
+      expect(format_currency(-12)).to eq("($12.00)")
     end
 
     it "should use the specified currency symbol when specified" do
       # S/. is the symbol for the Peruvian Nuevo Sol, just in case you were curious
-      format_currency(12, :symbol => "S/.").should == "S/.12.00"
+      expect(format_currency(12, :symbol => "S/.")).to eq("S/.12.00")
     end
 
     it "should use the currency code as the symbol if the currency code can't be identified" do
-      format_currency(12, :currency => "XYZ").should == "XYZ12.00"
+      expect(format_currency(12, :currency => "XYZ")).to eq("XYZ12.00")
     end
 
     it "should respect the :use_cldr_symbol option" do
-      format_currency(12, :currency => "CAD").should == "$12.00"
-      format_currency(12, :currency => "CAD", :use_cldr_symbol => true).should == "CA$12.00"
+      expect(format_currency(12, :currency => "CAD")).to eq("$12.00")
+      expect(format_currency(12, :currency => "CAD", :use_cldr_symbol => true)).to eq("CA$12.00")
     end
 
     it "should use the currency symbol for the corresponding currency code" do
-      format_currency(12, :currency => "THB").should == "฿12.00"
+      expect(format_currency(12, :currency => "THB")).to eq("฿12.00")
     end
 
     it "overrides the default precision" do
-      format_currency(12, :precision => 3).should == "$12.000"
+      expect(format_currency(12, :precision => 3)).to eq("$12.000")
     end
 
     it "should use the currency-specific default precision" do
-      format_currency(12, :currency => "TND").should == "TND12.000"
+      expect(format_currency(12, :currency => "TND")).to eq("TND12.000")
     end
 
     it "should use the currency rounding for the currency code" do
       # The rounding value for CHF changed from 5 to 0 in CLDR 23, so we have to pass
       # :rounding explicitly to test its effects.
-      format_currency(12.03, :currency => "CHF", :rounding => 5).should == "CHF12.05"
-      format_currency(12.02, :currency => "CHF", :rounding => 5).should == "CHF12.00"
+      expect(format_currency(12.03, :currency => "CHF", :rounding => 5)).to eq("CHF12.05")
+      expect(format_currency(12.02, :currency => "CHF", :rounding => 5)).to eq("CHF12.00")
     end
   end
 end

--- a/spec/formatters/numbers/decimal_formatter_spec.rb
+++ b/spec/formatters/numbers/decimal_formatter_spec.rb
@@ -18,20 +18,20 @@ describe DecimalFormatter do
     it "should format positive decimals correctly" do
       pattern = data_reader.pattern(number)
       tokens = tokenizer.tokenize(pattern)
-      formatter.format(tokens, number).should == "12"
+      expect(formatter.format(tokens, number)).to eq("12")
     end
 
     it "should format negative decimals correctly" do
       pattern = data_reader.pattern(negative_number)
       tokens = tokenizer.tokenize(pattern)
-      formatter.format(tokens, negative_number).should == "-12"
+      expect(formatter.format(tokens, negative_number)).to eq("-12")
     end
 
     it "should respect the :precision option" do
       { number => "12,000", negative_number => "-12,000" }.each_pair do |num, formatted|
         pattern = data_reader.pattern(num)
         tokens = tokenizer.tokenize(pattern)
-        formatter.format(tokens, num, :precision => 3).should == formatted
+        expect(formatter.format(tokens, num, :precision => 3)).to eq(formatted)
       end
     end
   end

--- a/spec/formatters/numbers/helpers/fraction_spec.rb
+++ b/spec/formatters/numbers/helpers/fraction_spec.rb
@@ -12,17 +12,17 @@ describe Fraction do
   describe "#apply" do
     it "test: formats a fraction" do
       token = Token.new(:value => '###.##', :type => :pattern)
-      Fraction.new(token).apply('45').should == '.45'
+      expect(Fraction.new(token).apply('45')).to eq('.45')
     end
 
     it "test: pads zero digits on the right side" do
       token = Token.new(:value => '###.0000#', :type => :pattern)
-      Fraction.new(token).apply('45').should == '.45000'
+      expect(Fraction.new(token).apply('45')).to eq('.45000')
     end
 
     it "test: :precision option overrides format precision" do
       token = Token.new(:value => '###.##', :type => :pattern)
-      Fraction.new(token).apply('78901', :precision => 5).should == '.78901'
+      expect(Fraction.new(token).apply('78901', :precision => 5)).to eq('.78901')
     end
   end
 end

--- a/spec/formatters/numbers/helpers/integer_spec.rb
+++ b/spec/formatters/numbers/helpers/integer_spec.rb
@@ -16,19 +16,19 @@ describe Integer do
       end
 
       it "test: interpolates a number" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123).should == '123'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123)).to eq('123')
       end
 
       it "test: does not include a fraction for a float" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123.45).should == '123'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123.45)).to eq('123')
       end
 
       it "test: does not round when given a float" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123.55).should == '123'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123.55)).to eq('123')
       end
 
       it "test: does not round with :precision => 1" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123.55, :precision => 1).should == '123'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123.55, :precision => 1)).to eq('123')
       end
     end
 
@@ -38,11 +38,11 @@ describe Integer do
       end
 
       it "test: single group" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123).should == '1,23'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123)).to eq('1,23')
       end
 
       it "test: multiple groups with a primary group size" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123456789).should == '1,23,45,67,89'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(123456789)).to eq('1,23,45,67,89')
       end
     end
 
@@ -52,53 +52,53 @@ describe Integer do
       end
 
       it "test: ignores a fraction part given in the format string" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(1234.567).should == '1,234'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(1234.567)).to eq('1,234')
       end
 
       it "test: cldr example #,##0.## => 1 234" do
-        TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(1234.567).should == '1,234'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(@token).apply(1234.567)).to eq('1,234')
       end
     end
 
     context "miscellaneous formats" do
       it "test: interpolates a number on the right side" do
         token = Token.new(:value => "0###", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123).should == '0123'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123)).to eq('0123')
       end
 
       it "test: strips optional digits" do
         token = Token.new(:value => "######", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123).should == '123'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123)).to eq('123')
       end
 
       it "test: multiple groups with a primary and secondary group size" do
         token = Token.new(:value => "#,##,##0", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123456789).should == '12,34,56,789'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123456789)).to eq('12,34,56,789')
       end
 
       it "test: does not group when no digits left of the grouping position" do
         token = Token.new(:value => "#,###", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123).should == '123'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token).apply(123)).to eq('123')
       end
 
       it "test: cldr example #,##0.### => 1 234" do
         token = Token.new(:value => "#,##0.###", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567).should == '1 234'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567)).to eq('1 234')
       end
 
       it "test: cldr example ###0.##### => 1234" do
         token = Token.new(:value => "###0.#####", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567).should == '1234'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567)).to eq('1234')
       end
 
       it "test: cldr example ###0.0000# => 1234" do
         token = Token.new(:value => "###0.0000#", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567).should == '1234'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567)).to eq('1234')
       end
 
       it "test: cldr example 00000.0000 => 01234" do
         token = Token.new(:value => "00000.0000", :type => :pattern)
-        TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567).should == '01234'
+        expect(TwitterCldr::Formatters::Numbers::Integer.new(token, :group => ' ').apply(1234.567)).to eq('01234')
       end
     end
   end

--- a/spec/formatters/numbers/number_formatter_spec.rb
+++ b/spec/formatters/numbers/number_formatter_spec.rb
@@ -25,33 +25,33 @@ describe NumberFormatter do
 
   describe "#precision_from" do
     it "should return the correct precision" do
-      formatter.send(:precision_from, 12.123).should == 3
+      expect(formatter.send(:precision_from, 12.123)).to eq(3)
     end
 
     it "should return zero precision if the number isn't a decimal" do
-      formatter.send(:precision_from, 12).should == 0
+      expect(formatter.send(:precision_from, 12)).to eq(0)
     end
   end
 
   describe "#round_to" do
     it "should round a number to the given precision" do
-      formatter.send(:round_to, 12, 0).should == 12
-      formatter.send(:round_to, 12.2, 0).should == 12
-      formatter.send(:round_to, 12.5, 0).should == 13
-      formatter.send(:round_to, 12.25, 1).should == 12.3
-      formatter.send(:round_to, 12.25, 2).should == 12.25
-      formatter.send(:round_to, 12.25, 3).should == 12.25
+      expect(formatter.send(:round_to, 12, 0)).to eq(12)
+      expect(formatter.send(:round_to, 12.2, 0)).to eq(12)
+      expect(formatter.send(:round_to, 12.5, 0)).to eq(13)
+      expect(formatter.send(:round_to, 12.25, 1)).to eq(12.3)
+      expect(formatter.send(:round_to, 12.25, 2)).to eq(12.25)
+      expect(formatter.send(:round_to, 12.25, 3)).to eq(12.25)
     end
   end
 
   describe "#parse_number" do
     it "should round and split the given number by decimal" do
-      formatter.send(:parse_number, 12, :precision => 0).should == ["12"]
-      formatter.send(:parse_number, 12.2, :precision => 0).should == ["12"]
-      formatter.send(:parse_number, 12.5, :precision => 0).should == ["13"]
-      formatter.send(:parse_number, 12.25, :precision => 1).should == ["12", "3"]
-      formatter.send(:parse_number, 12.25, :precision => 2).should == ["12", "25"]
-      formatter.send(:parse_number, 12.25, :precision => 3).should == ["12", "250"]
+      expect(formatter.send(:parse_number, 12, :precision => 0)).to eq(["12"])
+      expect(formatter.send(:parse_number, 12.2, :precision => 0)).to eq(["12"])
+      expect(formatter.send(:parse_number, 12.5, :precision => 0)).to eq(["13"])
+      expect(formatter.send(:parse_number, 12.25, :precision => 1)).to eq(["12", "3"])
+      expect(formatter.send(:parse_number, 12.25, :precision => 2)).to eq(["12", "25"])
+      expect(formatter.send(:parse_number, 12.25, :precision => 3)).to eq(["12", "250"])
     end
   end
 
@@ -62,33 +62,33 @@ describe NumberFormatter do
     end
 
     it "should format a basic integer" do
-      format_number(12).should == "12"
+      expect(format_number(12)).to eq("12")
     end
 
     it "should format a basic decimal" do
-      format_number(12.0).should == "12,0"
+      expect(format_number(12.0)).to eq("12,0")
     end
 
     context "should respect the :precision option" do
       it "formats with precision of 0" do
-        format_number(12.1, :precision => 0).should == "12"
+        expect(format_number(12.1, :precision => 0)).to eq("12")
       end
 
       it "rounds and formats with precision of 1" do
-        format_number(12.25, :precision => 1).should == "12,3"
+        expect(format_number(12.25, :precision => 1)).to eq("12,3")
       end
     end
 
     it "uses the length of the original decimal as the precision" do
-      format_number(12.8543).should == "12,8543"
+      expect(format_number(12.8543)).to eq("12,8543")
     end
 
     it "formats an integer larger than 999" do
-      format_number(1337).should == "1 337"
+      expect(format_number(1337)).to eq("1 337")
     end
 
     it "formats a decimal larger than 999.9" do
-      format_number(1337.37).should == "1 337,37"
+      expect(format_number(1337.37)).to eq("1 337,37")
     end
   end
 end

--- a/spec/formatters/numbers/percent_formatter_spec.rb
+++ b/spec/formatters/numbers/percent_formatter_spec.rb
@@ -17,18 +17,18 @@ describe PercentFormatter do
   it "should format the number correctly" do
     pattern = data_reader.pattern(number)
     tokens = tokenizer.tokenize(pattern)
-    formatter.format(tokens, number).should == "12 %"
+    expect(formatter.format(tokens, number)).to eq("12 %")
   end
 
   it "should format negative numbers correctly" do
     pattern = data_reader.pattern(negative_number)
     tokens = tokenizer.tokenize(pattern)
-    formatter.format(tokens, negative_number).should == "-12 %"
+    expect(formatter.format(tokens, negative_number)).to eq("-12 %")
   end
 
   it "should respect the :precision option" do
     pattern = data_reader.pattern(negative_number)
     tokens = tokenizer.tokenize(pattern)
-    formatter.format(tokens, negative_number, :precision => 3).should match_normalized("-12,000 %")
+    expect(formatter.format(tokens, negative_number, :precision => 3)).to match_normalized("-12,000 %")
   end
 end

--- a/spec/formatters/numbers/rbnf/rbnf_spec.rb
+++ b/spec/formatters/numbers/rbnf/rbnf_spec.rb
@@ -72,10 +72,10 @@ describe RbnfFormatter do
                       failures[locale][group_name] ||= {}
                       failures[locale][group_name][rule_set_name] ||= []
                       failures[locale][group_name][rule_set_name] << number
-                      got.should == expected
+                      expect(got).to eq(expected)
                     end
                   else
-                    got.should == expected
+                    expect(got).to eq(expected)
                   end
 
                 end

--- a/spec/formatters/plurals/plural_formatter_spec.rb
+++ b/spec/formatters/plurals/plural_formatter_spec.rb
@@ -11,11 +11,11 @@ describe PluralFormatter do
 
   describe '#initialize' do
     it 'fetches locale from options hash' do
-      PluralFormatter.new(:ru).locale.should == :ru
+      expect(PluralFormatter.new(:ru).locale).to eq(:ru)
     end
 
     it "uses current locale if it's not passed in options hash" do
-      PluralFormatter.new.locale.should == TwitterCldr.locale
+      expect(PluralFormatter.new.locale).to eq(TwitterCldr.locale)
     end
   end
 
@@ -38,47 +38,47 @@ describe PluralFormatter do
     context 'when there is nothing to pluralize' do
       it "doesn't change the string if no interpolation found" do
         string = 'no interpolation here'
-        subject.format(string, {}).should == string
+        expect(subject.format(string, {})).to eq(string)
       end
 
       context 'with regular pluralization' do
         it "doesn't change the string if a number is not provided" do
           string = 'there %{horses_count:horses}'
-          subject.format(string, :horses => horses).should == string
+          expect(subject.format(string, :horses => horses)).to eq(string)
         end
 
         it "doesn't change the string if a patterns hash is not provided" do
           string = 'there %{horses_count:horses}'
-          subject.format(string, :horses_count => 1).should == string
+          expect(subject.format(string, :horses_count => 1)).to eq(string)
         end
 
         it "doesn't change the string if required pattern is not provided" do
           string = 'there %{horses_count:horses}'
-          subject.format(string, :horses_count => 2, :horses => { :one => 'is 1 horse' }).should == string
+          expect(subject.format(string, :horses_count => 2, :horses => { :one => 'is 1 horse' })).to eq(string)
         end
       end
 
       context 'with inline pluralization' do
         it "doesn't change the string if a number is not provided" do
           string = "there #{horses_string}"
-          subject.format(string, {}).should == string
+          expect(subject.format(string, {})).to eq(string)
         end
 
         it "doesn't change the string if required pattern is not provided" do
           string = 'there %<{ "horses_count": {"one": "is 1 horse"} }>'
-          subject.format(string, :horses_count => 2).should == string
+          expect(subject.format(string, :horses_count => 2)).to eq(string)
         end
       end
 
       context 'with mixed pluralization' do
         it "doesn't change the string if a number is not provided" do
           string = "there #{horses_string} %{horses_count:horses}"
-          subject.format(string, :horses => horses).should == string
+          expect(subject.format(string, :horses => horses)).to eq(string)
         end
 
         it "doesn't change the string if required pattern is not provided" do
           string = 'there %<{ "horses_count": {"one": "is 1 horse"} }> %{horses_count:horses}'
-          subject.format(string, :horses_count => 2, :horses => { :one => 'is 1 horse' }).should == string
+          expect(subject.format(string, :horses_count => 2, :horses => { :one => 'is 1 horse' })).to eq(string)
         end
       end
     end
@@ -86,109 +86,109 @@ describe PluralFormatter do
     context 'when something should be pluralized' do
       context 'with regular pluralization' do
         it 'pluralizes with a simple replacement' do
-          subject.format(
+          expect(subject.format(
               'there %{horses_count:horses}',
               :horses_count => 1, :horses => horses
-          ).should == 'there is 1 horse'
+          )).to eq('there is 1 horse')
         end
 
         it 'pluralizes when there are named interpolation patterns in the string' do
-          subject.format(
+          expect(subject.format(
               '%{there} %{horses_count:horses}',
               :horses_count => 1, :horses => horses
-          ).should == '%{there} is 1 horse'
+          )).to eq('%{there} is 1 horse')
         end
 
         it 'supports multiple patterns sets for the same number' do
-          subject.format(
+          expect(subject.format(
               'there %{horses_count:to_be} %{horses_count:horses}',
               :horses_count => 1, :horses => simple_horses, :to_be => to_be
-          ).should == 'there is 1 horse'
+          )).to eq('there is 1 horse')
         end
 
         it 'pluralizes multiple entries' do
-          subject.format(
+          expect(subject.format(
               'there %{yaks_count:yaks} and %{horses_count:horses}',
               :yaks_count => 1, :yaks => yaks, :horses_count => 2, :horses => simple_horses
-          ).should == 'there is 1 yak and 2 horses'
+          )).to eq('there is 1 yak and 2 horses')
         end
 
         it 'substitutes the number for a placeholder in the pattern' do
-          subject.format(
+          expect(subject.format(
               'there %{horses_count:horses}',
               :horses_count => 3, :horses => horses
-          ).should == 'there are 3 horses'
+          )).to eq('there are 3 horses')
         end
 
         it 'substitutes the number for multiple placeholders in the pattern' do
-          subject.format(
+          expect(subject.format(
               'there are %{horses_count:horses}',
               :horses_count => 3, :horses => { :other => '%{horses_count}, seriously %{horses_count}, horses' }
-          ).should == 'there are 3, seriously 3, horses'
+          )).to eq('there are 3, seriously 3, horses')
         end
 
         it 'throws an exception if pluralization patterns is not a hash' do
-          lambda do
+          expect do
             subject.format('there %{horses_count:horses}', :horses_count => 1, :horses => [])
-          end.should raise_error(ArgumentError, 'expected patterns to be a Hash')
+          end.to raise_error(ArgumentError, 'expected patterns to be a Hash')
         end
       end
 
       context 'with inline pluralization' do
         it 'pluralizes with a simple replacement' do
-          subject.format("there #{horses_string}", :horses_count => 1).should == 'there is 1 horse'
+          expect(subject.format("there #{horses_string}", :horses_count => 1)).to eq('there is 1 horse')
         end
 
         it 'pluralizes when there are named interpolation patterns in the string' do
-          subject.format("%{there} #{horses_string}", :horses_count => 1).should == '%{there} is 1 horse'
+          expect(subject.format("%{there} #{horses_string}", :horses_count => 1)).to eq('%{there} is 1 horse')
         end
 
         it 'supports multiple patterns sets for the same number' do
-          subject.format(
+          expect(subject.format(
               %Q(there %<{ "horses_count": {"one": "is", "other": "are"} }> #{simple_horses_string}), :horses_count => 1
-          ).should == 'there is 1 horse'
+          )).to eq('there is 1 horse')
         end
 
         it 'pluralizes multiple entries' do
-          subject.format(
+          expect(subject.format(
               %Q(there %<{ "yaks_count": {"one": "is 1 yak", "other": "are %{yaks_count} yaks"} }> and #{simple_horses_string}),
               :yaks_count => 1, :horses_count => 2
-          ).should == 'there is 1 yak and 2 horses'
+          )).to eq('there is 1 yak and 2 horses')
         end
 
         it 'substitutes the number for a placeholder in the pattern' do
-          subject.format(
+          expect(subject.format(
               "there #{horses_string}", :horses_count => 3, :horses => horses
-          ).should == 'there are 3 horses'
+          )).to eq('there are 3 horses')
         end
 
         it 'substitutes the number for multiple placeholders in the pattern' do
-          subject.format(
+          expect(subject.format(
               'there are %<{ "horses_count": {"other": "%{horses_count}, seriously %{horses_count}, horses"} }>',
               :horses_count => 3
-          ).should == 'there are 3, seriously 3, horses'
+          )).to eq('there are 3, seriously 3, horses')
         end
 
         it 'throws an exception if pluralization hash has more than one key' do
-          lambda do
+          expect do
             subject.format('there are %<{ "horses_count": {}, "foo": {} }>', {})
-          end.should raise_error(ArgumentError, 'expected a Hash with a single key')
+          end.to raise_error(ArgumentError, 'expected a Hash with a single key')
         end
       end
 
       context 'with mixed pluralization' do
         it 'pluralizes separate groups' do
-          subject.format(
+          expect(subject.format(
               "there %{yaks_count:yaks} and #{simple_horses_string}",
               :yaks => yaks, :yaks_count => 3, :horses_count => 2
-          ).should == 'there are 3 yaks and 2 horses'
+          )).to eq('there are 3 yaks and 2 horses')
         end
 
         it 'pluralizes similar groups' do
-          subject.format(
+          expect(subject.format(
               "there %{horses_count:horses} + #{simple_horses_string}",
               :horses => horses, :horses_count => 2
-          ).should == 'there are 2 horses + 2 horses'
+          )).to eq('there are 2 horses + 2 horses')
         end
       end
     end
@@ -198,7 +198,7 @@ describe PluralFormatter do
   describe '#pluralization_rule' do
     it 'delegates pluralization rule fetching to Rules.rule_for method' do
       mock(Plurals::Rules).rule_for(42, :jp) { 'result' }
-      PluralFormatter.new(:jp).send(:pluralization_rule, 42).should == 'result'
+      expect(PluralFormatter.new(:jp).send(:pluralization_rule, 42)).to eq('result')
     end
   end
 

--- a/spec/formatters/plurals/rules_spec.rb
+++ b/spec/formatters/plurals/rules_spec.rb
@@ -12,17 +12,17 @@ describe Rules do
     it "calls eval on the hash that gets returned, lambdas and all" do
       result = Rules.send(:get_resource, :ru)
 
-      result.should include(:keys, :rule)
-      result[:keys].size.should == 3
-      result[:rule].should be_a(Proc)
+      expect(result).to include(:keys, :rule)
+      expect(result[:keys].size).to eq(3)
+      expect(result[:rule]).to be_a(Proc)
     end
   end
 
   describe "#rule_for" do
     it "returns :one for English 1, :other for everything else" do
-      Rules.rule_for(1, :en).should == :one
+      expect(Rules.rule_for(1, :en)).to eq(:one)
       [5, 9, 10, 20, 60, 99, 100, 103, 141].each do |num|
-        Rules.rule_for(num, :en).should == :other
+        expect(Rules.rule_for(num, :en)).to eq(:other)
       end
     end
 
@@ -34,34 +34,34 @@ describe Rules do
       }
 
       rules.each do |rule, examples|
-        examples.each { |n| Rules.rule_for(n, :ru).should == rule }
+        examples.each { |n| expect(Rules.rule_for(n, :ru)).to eq(rule) }
       end
     end
 
     it "returns :other if there's an error" do
       stub(Rules).get_resource { lambda { raise "Jelly beans" } }
-      Rules.rule_for(1, :en).should == :other
-      Rules.rule_for(1, :ru).should == :other
+      expect(Rules.rule_for(1, :en)).to eq(:other)
+      expect(Rules.rule_for(1, :ru)).to eq(:other)
     end
   end
 
   describe "#all_for" do
     it "returns a list of all applicable rules for the given locale" do
-      Rules.all_for(:en).should =~ [:one, :other]
-      Rules.all_for(:ru).should =~ [:one, :many, :other]
+      expect(Rules.all_for(:en)).to match_array([:one, :other])
+      expect(Rules.all_for(:ru)).to match_array([:one, :many, :other])
     end
 
     it "returns nil on error" do
       stub(Rules).get_resource { lambda { raise "Jelly beans" } }
-      Rules.all_for(:en).should be_nil
-      Rules.all_for(:ru).should be_nil
+      expect(Rules.all_for(:en)).to be_nil
+      expect(Rules.all_for(:ru)).to be_nil
     end
   end
 
   describe "#all" do
     it "gets rules for the default locale (usually supplied by FastGettext)" do
       mock(TwitterCldr).locale { :ru }
-      Rules.all.should =~ [:one, :many, :other]
+      expect(Rules.all).to match_array([:one, :many, :other])
     end
   end
 end

--- a/spec/localized/localized_array_spec.rb
+++ b/spec/localized/localized_array_spec.rb
@@ -10,7 +10,7 @@ include TwitterCldr::Localized
 describe LocalizedArray do
   describe '#code_points_to_string' do
     it 'transforms an array of code points into a string' do
-      [0x74, 0x77, 0x69, 0x74, 0x74, 0x65, 0x72].localize.code_points_to_string.should == 'twitter'
+      expect([0x74, 0x77, 0x69, 0x74, 0x74, 0x65, 0x72].localize.code_points_to_string).to eq('twitter')
     end
   end
 
@@ -24,25 +24,25 @@ describe LocalizedArray do
 
     describe '#sort' do
       it 'returns a new LocalizedArray' do
-        localized.sort.should be_instance_of(LocalizedArray)
+        expect(localized.sort).to be_instance_of(LocalizedArray)
       end
 
       it 'does not change the original array' do
-        lambda { localized.sort }.should_not change { localized.base_obj }
+        expect { localized.sort }.not_to change { localized.base_obj }
       end
 
       it 'sorts strings in the array with corresponding collator' do
-        localized.sort.base_obj.should == sorted
+        expect(localized.sort.base_obj).to eq(sorted)
       end
     end
 
     describe '#sort!' do
       it 'returns self' do
-        localized.sort!.object_id.should == localized.object_id
+        expect(localized.sort!.object_id).to eq(localized.object_id)
       end
 
       it 'sorts the array in-place' do
-        localized.sort!.base_obj.should == sorted
+        expect(localized.sort!.base_obj).to eq(sorted)
       end
     end
   end
@@ -53,14 +53,14 @@ describe LocalizedArray do
       index = 0
 
       arr.localize.each do |item|
-        arr[index].should == item
+        expect(arr[index]).to eq(item)
         index += 1
       end
     end
 
     it "should support a few of the other methods in Enumerable" do
-      [1, 2, 3].localize.inject(0) { |sum, num| sum += num; sum }.should == 6
-      [1, 2, 3].localize.map { |item| item + 1 }.should == [2, 3, 4]
+      expect([1, 2, 3].localize.inject(0) { |sum, num| sum += num; sum }).to eq(6)
+      expect([1, 2, 3].localize.map { |item| item + 1 }).to eq([2, 3, 4])
     end
   end
 
@@ -69,9 +69,9 @@ describe LocalizedArray do
       arr = [:foo, "bar", Object.new]
       result = YAML.load(arr.localize.to_yaml)
 
-      result[0].should == :foo
-      result[1].should == "bar"
-      result[2].should be_a(Object)
+      expect(result[0]).to eq(:foo)
+      expect(result[1]).to eq("bar")
+      expect(result[2]).to be_a(Object)
     end
   end
 end

--- a/spec/localized/localized_date_spec.rb
+++ b/spec/localized/localized_date_spec.rb
@@ -18,45 +18,45 @@ describe LocalizedDate do
     it "should ago-ify from now when no base_time given" do
       stub(Time).now { Time.gm(2010, 8, 6, 12, 12, 30) }
       loc_date = date_time.localize(:ko).to_date
-      loc_date.ago.to_s(:unit => :hour).should match_normalized("744시간 전")
+      expect(loc_date.ago.to_s(:unit => :hour)).to match_normalized("744시간 전")
     end
 
     it "should ago-ify with appropriate unit when no unit given" do
       loc_date = date_time.localize(:en).to_date
-      loc_date.ago(:base_time => base_time).to_s.should match_normalized("1 month ago")
-      loc_date.ago(:base_time => Time.gm(2010, 12, 6, 12, 12, 30)).to_s.should match_normalized("5 months ago")
-      loc_date.ago(:base_time => Time.gm(2010, 7, 7, 12, 12, 30)).to_s.should match_normalized("1 day ago")
+      expect(loc_date.ago(:base_time => base_time).to_s).to match_normalized("1 month ago")
+      expect(loc_date.ago(:base_time => Time.gm(2010, 12, 6, 12, 12, 30)).to_s).to match_normalized("5 months ago")
+      expect(loc_date.ago(:base_time => Time.gm(2010, 7, 7, 12, 12, 30)).to_s).to match_normalized("1 day ago")
     end
 
     it "should ago-ify with strings regardless of variable's placement or existence" do
       loc_date = date_time.localize(:ar).to_date
-      loc_date.ago(:base_time => base_time).to_s(:unit => :hour).should match_normalized("قبل 744 ساعة")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :day).should match_normalized("قبل 31 يومًا")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :month).should match_normalized("قبل 1 من الشهور")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :year).should match_normalized("قبل 0 من السنوات")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :hour)).to match_normalized("قبل 744 ساعة")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :day)).to match_normalized("قبل 31 يومًا")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :month)).to match_normalized("قبل 1 من الشهور")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :year)).to match_normalized("قبل 0 من السنوات")
 
       loc_date = date_time.localize(:fa).to_date
-      loc_date.ago(:base_time => base_time).to_s(:unit => :day).should match_normalized("31 روز پیش")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :day)).to match_normalized("31 روز پیش")
 
       loc_date = date_time.localize(:en).to_date
-      loc_date.ago(:base_time => base_time).to_s(:unit => :day).should match_normalized("31 days ago")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :day)).to match_normalized("31 days ago")
     end
 
     it "should ago-ify a date with a number of different units" do
       date_time = DateTime.new(2010, 6, 6, 12, 12, 30)
       loc_date = date_time.localize(:de).to_date
-      loc_date.ago(:base_time => base_time).to_s(:unit => :second).should match_normalized("Vor 5270400 Sekunden")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :minute).should match_normalized("Vor 87840 Minuten")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :hour).should match_normalized("Vor 1464 Stunden")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :day).should match_normalized("Vor 61 Tagen")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :month).should match_normalized("Vor 2 Monaten")
-      loc_date.ago(:base_time => base_time).to_s(:unit => :year).should match_normalized("Vor 0 Jahren")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :second)).to match_normalized("Vor 5270400 Sekunden")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :minute)).to match_normalized("Vor 87840 Minuten")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :hour)).to match_normalized("Vor 1464 Stunden")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :day)).to match_normalized("Vor 61 Tagen")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :month)).to match_normalized("Vor 2 Monaten")
+      expect(loc_date.ago(:base_time => base_time).to_s(:unit => :year)).to match_normalized("Vor 0 Jahren")
     end
 
     it "should return an error if called on a date in the future" do
       date_time = DateTime.new(2010, 10, 10, 12, 12, 30)
       loc_date = date_time.localize(:de).to_date
-      lambda { loc_date.ago(base_time, :second)}.should raise_error(ArgumentError)
+      expect { loc_date.ago(base_time, :second)}.to raise_error(ArgumentError)
     end
   end
 
@@ -66,18 +66,18 @@ describe LocalizedDate do
     it "should until-ify with a number of different units" do
       date_time = DateTime.new(2010, 10, 10, 12, 12, 30)
       loc_date = date_time.localize(:de).to_date
-      loc_date.until(:base_time => base_time).to_s(:unit => :second).should match_normalized("In 5616000 Sekunden")
-      loc_date.until(:base_time => base_time).to_s(:unit => :minute).should match_normalized("In 93600 Minuten")
-      loc_date.until(:base_time => base_time).to_s(:unit => :hour).should match_normalized("In 1560 Stunden")
-      loc_date.until(:base_time => base_time).to_s(:unit => :day).should match_normalized("In 65 Tagen")
-      loc_date.until(:base_time => base_time).to_s(:unit => :month).should match_normalized("In 2 Monaten")
-      loc_date.until(:base_time => base_time).to_s(:unit => :year).should match_normalized("In 0 Jahren")
+      expect(loc_date.until(:base_time => base_time).to_s(:unit => :second)).to match_normalized("In 5616000 Sekunden")
+      expect(loc_date.until(:base_time => base_time).to_s(:unit => :minute)).to match_normalized("In 93600 Minuten")
+      expect(loc_date.until(:base_time => base_time).to_s(:unit => :hour)).to match_normalized("In 1560 Stunden")
+      expect(loc_date.until(:base_time => base_time).to_s(:unit => :day)).to match_normalized("In 65 Tagen")
+      expect(loc_date.until(:base_time => base_time).to_s(:unit => :month)).to match_normalized("In 2 Monaten")
+      expect(loc_date.until(:base_time => base_time).to_s(:unit => :year)).to match_normalized("In 0 Jahren")
     end
 
     it "should return an error if called on a date in the past" do
       date_time = DateTime.new(2010, 4, 4, 12, 12, 30)
       loc_date = date_time.localize(:de).to_date
-      lambda { loc_date.until(base_time, :second)}.should raise_error(ArgumentError)
+      expect { loc_date.until(base_time, :second)}.to raise_error(ArgumentError)
     end
   end
 
@@ -91,7 +91,7 @@ describe LocalizedDate do
 
     it "should stringify with buddhist calendar" do
       # Ensure that buddhist calendar data is present in th locale.
-      TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist].should_not(
+      expect(TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist]).not_to(
         be_nil, 'buddhist calendar is missing for :th locale (check resources/locales/th/calendars.yml)'
       )
 
@@ -107,16 +107,16 @@ describe LocalizedDate do
       date_time = DateTime.new(1987, 9, 20, 0, 0, 0)
       time = Time.local(2000, 5, 12, 22, 5)
       datetime = date_time.localize.to_date.to_datetime(time)
-      datetime.should be_a(LocalizedDateTime)
-      datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S").should == "1987-09-20 22:05:00"
+      expect(datetime).to be_a(LocalizedDateTime)
+      expect(datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S")).to eq("1987-09-20 22:05:00")
     end
 
     it "should work with an instance of LocalizedTime too" do
       date_time = DateTime.new(1987, 9, 20, 0, 0, 0)
       time = Time.local(2000, 5, 12, 22, 5).localize
       datetime = date_time.localize.to_date.to_datetime(time)
-      datetime.should be_a(LocalizedDateTime)
-      datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S").should == "1987-09-20 22:05:00"
+      expect(datetime).to be_a(LocalizedDateTime)
+      expect(datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S")).to eq("1987-09-20 22:05:00")
     end
   end
 
@@ -124,7 +124,7 @@ describe LocalizedDate do
     it "don't raise errors for any locale" do
       TwitterCldr.supported_locales.each do |locale|
         (LocalizedDate.types - [:additional]).each do |type|
-          lambda { DateTime.now.localize(locale).to_date.send(:"to_#{type}_s") }.should_not raise_error
+          expect { DateTime.now.localize(locale).to_date.send(:"to_#{type}_s") }.not_to raise_error
         end
       end
     end
@@ -133,9 +133,9 @@ describe LocalizedDate do
   describe "#with_timezone" do
     it "calculates the right day depending on the timezone" do
       loc_date = DateTime.new(1987, 9, 20, 0, 0, 0).localize.to_date
-      loc_date.to_s.should == "Sep 20, 1987"
-      loc_date.with_timezone("America/Los_Angeles").to_s.should == "Sep 19, 1987"
-      loc_date.with_timezone("Asia/Tokyo").to_s.should == "Sep 20, 1987"
+      expect(loc_date.to_s).to eq("Sep 20, 1987")
+      expect(loc_date.with_timezone("America/Los_Angeles").to_s).to eq("Sep 19, 1987")
+      expect(loc_date.with_timezone("Asia/Tokyo").to_s).to eq("Sep 20, 1987")
     end
   end
 

--- a/spec/localized/localized_datetime_spec.rb
+++ b/spec/localized/localized_datetime_spec.rb
@@ -13,11 +13,11 @@ describe LocalizedDateTime do
 
   describe '#initilize' do
     it 'sets calendar type' do
-      date_time.localize(:th, :calendar_type => :buddhist).calendar_type.should == :buddhist
+      expect(date_time.localize(:th, :calendar_type => :buddhist).calendar_type).to eq(:buddhist)
     end
 
     it 'uses default calendar type' do
-      date_time.localize(:en).calendar_type.should == TwitterCldr::DEFAULT_CALENDAR_TYPE
+      expect(date_time.localize(:en).calendar_type).to eq(TwitterCldr::DEFAULT_CALENDAR_TYPE)
     end
   end
 
@@ -31,7 +31,7 @@ describe LocalizedDateTime do
 
     it "should stringify with buddhist calendar" do
       # Ensure that buddhist calendar data is present in th locale.
-      TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist].should_not(
+      expect(TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist]).not_to(
         be_nil, 'buddhist calendar is missing for :th locale (check resources/locales/th/calendars.yml)'
       )
 
@@ -44,7 +44,7 @@ describe LocalizedDateTime do
 
   describe "#to_date" do
     it "should convert to a date" do
-      date_time.localize.to_date.base_obj.strftime("%Y-%m-%d").should == "1987-09-20"
+      expect(date_time.localize.to_date.base_obj.strftime("%Y-%m-%d")).to eq("1987-09-20")
     end
 
     it 'forwards calendar type' do
@@ -54,7 +54,7 @@ describe LocalizedDateTime do
 
   describe "#to_time" do
     it "should convert to a time" do
-      date_time.localize.to_time.base_obj.getgm.strftime("%H:%M:%S").should == "22:05:00"
+      expect(date_time.localize.to_time.base_obj.getgm.strftime("%H:%M:%S")).to eq("22:05:00")
     end
 
     it 'forwards calendar type' do
@@ -64,7 +64,7 @@ describe LocalizedDateTime do
 
   describe "#to_timespan" do
     it "should return a localized timespan" do
-      date_time.localize.to_timespan.should be_a(LocalizedTimespan)
+      expect(date_time.localize.to_timespan).to be_a(LocalizedTimespan)
     end
   end
 
@@ -72,7 +72,7 @@ describe LocalizedDateTime do
     it "don't raise errors for any locale" do
       TwitterCldr.supported_locales.each do |locale|
         (TwitterCldr::DataReaders::CalendarDataReader.types - [:additional]).each do |type|
-          lambda { date_time.localize(locale).send(:"to_#{type}_s") }.should_not raise_error
+          expect { date_time.localize(locale).send(:"to_#{type}_s") }.not_to raise_error
         end
       end
     end
@@ -93,16 +93,16 @@ describe LocalizedDateTime do
     it "uses the default format if no :format is given" do
       loc_date = date_time.localize
       mock.proxy(loc_date).to_default_s
-      loc_date.to_s.should == "Sep 20, 1987, 10:05:00 PM"
+      expect(loc_date.to_s).to eq("Sep 20, 1987, 10:05:00 PM")
     end
   end
 
   describe "#with_timezone" do
     it "calculates the right time depending on the timezone" do
       loc_date = date_time.localize
-      loc_date.to_s.should == "Sep 20, 1987, 10:05:00 PM"
-      loc_date.with_timezone("America/Los_Angeles").to_s.should == "Sep 20, 1987, 3:05:00 PM"
-      loc_date.with_timezone("America/New_York").to_s.should == "Sep 20, 1987, 6:05:00 PM"
+      expect(loc_date.to_s).to eq("Sep 20, 1987, 10:05:00 PM")
+      expect(loc_date.with_timezone("America/Los_Angeles").to_s).to eq("Sep 20, 1987, 3:05:00 PM")
+      expect(loc_date.with_timezone("America/New_York").to_s).to eq("Sep 20, 1987, 6:05:00 PM")
     end
   end
 

--- a/spec/localized/localized_hash_spec.rb
+++ b/spec/localized/localized_hash_spec.rb
@@ -13,10 +13,10 @@ describe LocalizedHash do
       hash = { :foo => "bar", "string_key" => Object.new }
       result = YAML.load(hash.localize.to_yaml)
 
-      result.should include(:foo)
-      result.should include("string_key")
-      result[:foo].should == "bar"
-      result["string_key"].should be_a(Object)
+      expect(result).to include(:foo)
+      expect(result).to include("string_key")
+      expect(result[:foo]).to eq("bar")
+      expect(result["string_key"]).to be_a(Object)
     end
   end
 end

--- a/spec/localized/localized_number_spec.rb
+++ b/spec/localized/localized_number_spec.rb
@@ -14,16 +14,16 @@ describe LocalizedNumber do
     let(:currency) { LocalizedNumber.new(10, :en, :type => :currency) }
 
     it 'uses nil type by default (defers decision to data reader)' do
-      decimal.type.should == nil
+      expect(decimal.type).to eq(nil)
     end
 
     it 'uses provided type if there is one' do
-      currency.type.should == :currency
+      expect(currency.type).to eq(:currency)
     end
 
     it 'sets up object with correct locale, falls back to default locale' do
-      LocalizedNumber.new(10, :es).locale.should == :es
-      LocalizedNumber.new(10, :blarg).locale.should == TwitterCldr::DEFAULT_LOCALE
+      expect(LocalizedNumber.new(10, :es).locale).to eq(:es)
+      expect(LocalizedNumber.new(10, :blarg).locale).to eq(TwitterCldr::DEFAULT_LOCALE)
     end
   end
 
@@ -36,20 +36,20 @@ describe LocalizedNumber do
         let(:method) { "to_#{type}" }
 
         it 'creates a new object' do
-          number.send(method).object_id.should_not == number.object_id
+          expect(number.send(method).object_id).not_to eq(number.object_id)
         end
 
         it 'creates an object of the appropriate type, but does not change the type of the original object' do
           new_number = currency.send(method)
-          new_number.type.should == type
-          currency.type.should == :currency
+          expect(new_number.type).to eq(type)
+          expect(currency.type).to eq(:currency)
         end
 
         it 'creates a new object with the same base object and locale' do
           percent = LocalizedNumber.new(42, :fr, :type => :percent)
           new_percent = percent.send(method)
-          new_percent.locale.should == :fr
-          new_percent.base_obj.should == 42
+          expect(new_percent.locale).to eq(:fr)
+          expect(new_percent.base_obj).to eq(42)
         end
       end
     end
@@ -57,20 +57,20 @@ describe LocalizedNumber do
 
   describe '#to_s' do
     it 'raises ArguemntError if unsupported type is passed' do
-      lambda do
+      expect do
         LocalizedNumber.new(10, :en, :type => :foo).to_s
-      end.should raise_error(ArgumentError, 'Type foo is not supported')
+      end.to raise_error(ArgumentError, 'Type foo is not supported')
     end
 
     context 'decimals' do
       let(:number) { LocalizedNumber.new(10, :en) }
 
       it 'should default precision to zero' do
-        number.to_s.should == "10"
+        expect(number.to_s).to eq("10")
       end
 
       it 'should not overwrite precision when explicitly passed' do
-        number.to_s(:precision => 2).should == "10.00"
+        expect(number.to_s(:precision => 2)).to eq("10.00")
       end
     end
 
@@ -78,11 +78,11 @@ describe LocalizedNumber do
       let(:number) { LocalizedNumber.new(10, :en, :type => :currency) }
 
       it "should default to a precision of 2" do
-        number.to_s(:precision => 2).should == "$10.00"
+        expect(number.to_s(:precision => 2)).to eq("$10.00")
       end
 
       it 'should not overwrite precision when explicitly passed' do
-        number.to_s(:precision => 1).should == "$10.0"
+        expect(number.to_s(:precision => 1)).to eq("$10.0")
       end
     end
 
@@ -90,11 +90,11 @@ describe LocalizedNumber do
       let(:number) { LocalizedNumber.new(10, :en, :type => :percent) }
 
       it "should default to a precision of 0" do
-        number.to_s.should == "10%"
+        expect(number.to_s).to eq("10%")
       end
 
       it 'should not overwrite precision when explicitly passed' do
-        number.to_s(:precision => 1).should == "10.0%"
+        expect(number.to_s(:precision => 1)).to eq("10.0%")
       end
     end
 
@@ -102,11 +102,11 @@ describe LocalizedNumber do
       let(:number) { LocalizedNumber.new(1000, :en, :type => :short_decimal) }
 
       it "should default to a precision of 0" do
-        number.to_s.should == "1K"
+        expect(number.to_s).to eq("1K")
       end
 
       it 'should not overwrite precision when explicitly passed' do
-        number.to_s(:precision => 1).should == "1.0K"
+        expect(number.to_s(:precision => 1)).to eq("1.0K")
       end
     end
 
@@ -114,57 +114,57 @@ describe LocalizedNumber do
       let(:number) { LocalizedNumber.new(1000, :en, :type => :long_decimal) }
 
       it "should default to a precision of 0" do
-        number.to_s.should == "1 thousand"
+        expect(number.to_s).to eq("1 thousand")
       end
 
       it 'should not overwrite precision when explicitly passed' do
-        number.to_s(:precision => 1).should == "1.0 thousand"
+        expect(number.to_s(:precision => 1)).to eq("1.0 thousand")
       end
     end
   end
 
   describe '#plural_rule' do
     it 'returns the appropriate plural rule for the number' do
-      1.localize(:ru).plural_rule.should == :one
-      2.localize(:ru).plural_rule.should == :other
-      5.localize(:ru).plural_rule.should == :many
+      expect(1.localize(:ru).plural_rule).to eq(:one)
+      expect(2.localize(:ru).plural_rule).to eq(:other)
+      expect(5.localize(:ru).plural_rule).to eq(:many)
     end
 
     it 'takes FastGettext.locale into account' do
       FastGettext.locale = :es
-      1.localize.plural_rule.should == :one
-      2.localize.plural_rule.should == :other
-      5.localize.plural_rule.should == :other
+      expect(1.localize.plural_rule).to eq(:one)
+      expect(2.localize.plural_rule).to eq(:other)
+      expect(5.localize.plural_rule).to eq(:other)
     end
   end
 
   describe 'formatters for every locale' do
     it "makes sure currency formatters for every locale don't raise errors" do
       TwitterCldr.supported_locales.each do |locale|
-        lambda { 1337.localize(locale).to_currency.to_s }.should_not raise_error
-        lambda { 1337.localize(locale).to_currency.to_s(:precision => 3) }.should_not raise_error
-        lambda { 1337.localize(locale).to_currency.to_s(:precision => 3, :currency => "EUR") }.should_not raise_error
+        expect { 1337.localize(locale).to_currency.to_s }.not_to raise_error
+        expect { 1337.localize(locale).to_currency.to_s(:precision => 3) }.not_to raise_error
+        expect { 1337.localize(locale).to_currency.to_s(:precision => 3, :currency => "EUR") }.not_to raise_error
       end
     end
 
     it "makes sure decimal formatters for every locale don't raise errors" do
       TwitterCldr.supported_locales.each do |locale|
-        lambda { 1337.localize(locale).to_decimal.to_s }.should_not raise_error
-        lambda { 1337.localize(locale).to_decimal.to_s(:precision => 3) }.should_not raise_error
+        expect { 1337.localize(locale).to_decimal.to_s }.not_to raise_error
+        expect { 1337.localize(locale).to_decimal.to_s(:precision => 3) }.not_to raise_error
       end
     end
 
     it "makes sure percentage formatters for every locale don't raise errors" do
       TwitterCldr.supported_locales.each do |locale|
-        lambda { 1337.localize(locale).to_percent.to_s }.should_not raise_error
-        lambda { 1337.localize(locale).to_percent.to_s(:precision => 3) }.should_not raise_error
+        expect { 1337.localize(locale).to_percent.to_s }.not_to raise_error
+        expect { 1337.localize(locale).to_percent.to_s(:precision => 3) }.not_to raise_error
       end
     end
 
     it "makes sure basic number formatters for every locale don't raise errors" do
       TwitterCldr.supported_locales.each do |locale|
-        lambda { 1337.localize(locale).to_s }.should_not raise_error
-        lambda { 1337.localize(locale).to_s(:precision => 3) }.should_not raise_error
+        expect { 1337.localize(locale).to_s }.not_to raise_error
+        expect { 1337.localize(locale).to_s(:precision => 3) }.not_to raise_error
       end
     end
   end

--- a/spec/localized/localized_object_spec.rb
+++ b/spec/localized/localized_object_spec.rb
@@ -26,23 +26,23 @@ describe LocalizedObject do
     let(:options) { { :foobar => 'value' } }
 
     it 'sets base object' do
-      localized_object.base_obj.should == base_object
+      expect(localized_object.base_obj).to eq(base_object)
     end
 
     it 'sets locale' do
-      localized_object.locale.should == locale
+      expect(localized_object.locale).to eq(locale)
     end
 
     it 'converts locale' do
-      LocalizedClass.new(base_object, :msa).locale.should == :ms
+      expect(LocalizedClass.new(base_object, :msa).locale).to eq(:ms)
     end
 
     it 'falls back to default locale if unsupported locale is passed' do
-      LocalizedClass.new(base_object, :foobar).locale.should == TwitterCldr::DEFAULT_LOCALE
+      expect(LocalizedClass.new(base_object, :foobar).locale).to eq(TwitterCldr::DEFAULT_LOCALE)
     end
 
     it "doesn't change original options hash" do
-      lambda { LocalizedClass.new(base_object, locale, options) }.should_not change { options }
+      expect { LocalizedClass.new(base_object, locale, options) }.not_to change { options }
     end
   end
 
@@ -50,9 +50,9 @@ describe LocalizedObject do
     it 'defines #localize method on a class' do
       some_class = Class.new
 
-      some_class.new.should_not respond_to(:localize)
+      expect(some_class.new).not_to respond_to(:localize)
       LocalizedClass.localize(some_class)
-      some_class.new.should respond_to(:localize)
+      expect(some_class.new).to respond_to(:localize)
     end
   end
 
@@ -67,7 +67,7 @@ describe LocalizedObject do
     end
 
     it 'returns localized object' do
-      localizable_object.localize.should be_a(LocalizedClass)
+      expect(localizable_object.localize).to be_a(LocalizedClass)
     end
 
     it 'accepts locale and options and pass them to the localized class constructor' do

--- a/spec/localized/localized_string_spec.rb
+++ b/spec/localized/localized_string_spec.rb
@@ -11,19 +11,19 @@ describe LocalizedString do
   describe '#%' do
     context 'when argument is not a Hash' do
       it 'performs regular formatting of values' do
-        ('%d is an integer'.localize % 3.14).should == '3 is an integer'
+        expect('%d is an integer'.localize % 3.14).to eq('3 is an integer')
       end
 
       it 'performs regular formatting of arrays' do
-        ('"% 04d" is a %s'.localize % [12, 'number']).should == '" 012" is a number'
+        expect('"% 04d" is a %s'.localize % [12, 'number']).to eq('" 012" is a number')
       end
 
       it 'ignores pluralization placeholders' do
-        ('%s: %{horses_count:horses}'.localize % 'total').should == 'total: %{horses_count:horses}'
+        expect('%s: %{horses_count:horses}'.localize % 'total').to eq('total: %{horses_count:horses}')
       end
 
       it 'raises ArgumentError when the string contains named placeholder' do
-        lambda { '%{msg}: %{horses_count:horses}'.localize % 'total' }.should raise_error(ArgumentError)
+        expect { '%{msg}: %{horses_count:horses}'.localize % 'total' }.to raise_error(ArgumentError)
       end
     end
 
@@ -35,47 +35,47 @@ describe LocalizedString do
       end
 
       it 'interpolates named placeholders' do
-        ('%<num>.2f is a %{noun}'.localize % { :num => 3.1415, :noun => 'number' }).should == '3.14 is a number'
+        expect('%<num>.2f is a %{noun}'.localize % { :num => 3.1415, :noun => 'number' }).to eq('3.14 is a number')
       end
 
       it 'performs regular pluralization' do
-        ('%{horses_count:horses}'.localize % { :horses_count => 2, :horses => horses }).should == '2 horses'
+        expect('%{horses_count:horses}'.localize % { :horses_count => 2, :horses => horses }).to eq('2 horses')
       end
 
       it 'performs inline pluralization' do
         string = '%<{ "horses_count": { "other": "%{horses_count} horses" } }>'.localize
-        (string % { :horses_count => 2 }).should == '2 horses'
+        expect(string % { :horses_count => 2 }).to eq('2 horses')
       end
 
       it 'performs both formatting and regular pluralization simultaneously' do
         string = '%{msg}: %{horses_count:horses}'.localize
-        (string % { :horses_count => 2, :horses => horses, :msg => 'result' }).should == 'result: 2 horses'
+        expect(string % { :horses_count => 2, :horses => horses, :msg => 'result' }).to eq('result: 2 horses')
       end
 
       it 'performs both formatting and inline pluralization simultaneously' do
         string = '%{msg}: %<{"horses_count": {"other": "%{horses_count} horses"}}>'.localize
-        (string % { :horses_count => 2, :msg => 'result' }).should == 'result: 2 horses'
+        expect(string % { :horses_count => 2, :msg => 'result' }).to eq('result: 2 horses')
       end
 
       it 'performs both formatted interpolation and inline pluralization simultaneously' do
         string = '%<number>d, %<{"horses_count": {"other": "%{horses_count} horses" }}>'.localize
-        (string % { :number => 3.14, :horses_count => 2 }).should == '3, 2 horses'
+        expect(string % { :number => 3.14, :horses_count => 2 }).to eq('3, 2 horses')
       end
 
       it 'leaves regular pluralization placeholders unchanged if not enough information given' do
         string = '%{msg}: %{horses_count:horses}'.localize
-        (string % { :msg => 'no pluralization' } ).should == 'no pluralization: %{horses_count:horses}'
+        expect(string % { :msg => 'no pluralization' } ).to eq('no pluralization: %{horses_count:horses}')
       end
 
       it 'leaves inline pluralization placeholders unchanged if not enough information given' do
         string = '%<number>d, %<{"horses_count": {"one": "one horse"}}>'.localize
-        (string % { :number => 3.14, :horses_count => 2 }).should == '3, %<{"horses_count": {"one": "one horse"}}>'
+        expect(string % { :number => 3.14, :horses_count => 2 }).to eq('3, %<{"horses_count": {"one": "one horse"}}>')
       end
 
       it 'raises KeyError when value for a named placeholder is missing' do
-        lambda do
+        expect do
           '%{msg}: %{horses_count:horses}'.localize % { :horses_count => 2, :horses => horses }
-        end.should raise_error(KeyError)
+        end.to raise_error(KeyError)
       end
     end
   end
@@ -85,41 +85,41 @@ describe LocalizedString do
       string = "galoshes"
       result = string.localize.to_s
 
-      result.should == string
-      result.equal?(string).should_not be_true
+      expect(result).to eq(string)
+      expect(result.equal?(string)).not_to be_true
     end
   end
 
   describe "#to_f" do
     it "should correctly parse a number with a thousands separator" do
-      "1,300".localize.to_f.should == 1300.0
-      "1.300".localize(:es).to_f.should == 1300.0
+      expect("1,300".localize.to_f).to eq(1300.0)
+      expect("1.300".localize(:es).to_f).to eq(1300.0)
     end
 
     it "should correctly parse a number with a decimal separator" do
-      "1.300".localize.to_f.should == 1.3
-      "1,300".localize(:es).to_f.should == 1.3
+      expect("1.300".localize.to_f).to eq(1.3)
+      expect("1,300".localize(:es).to_f).to eq(1.3)
     end
 
     it "should correctly parse a number with a thousands and a decimal separator" do
-      "1,300.05".localize.to_f.should == 1300.05
-      "1.300,05".localize(:es).to_f.should == 1300.05
+      expect("1,300.05".localize.to_f).to eq(1300.05)
+      expect("1.300,05".localize(:es).to_f).to eq(1300.05)
     end
 
     it "should return zero if the string contains no numbers" do
-      "abc".localize.to_f.should == 0.0
+      expect("abc".localize.to_f).to eq(0.0)
     end
 
     it "should return only the numbers at the beginning of the string if the string contains any non-numeric characters" do
-      "1abc".localize.to_f.should == 1.0
-      "a1bc".localize.to_f.should == 0.0
+      expect("1abc".localize.to_f).to eq(1.0)
+      expect("a1bc".localize.to_f).to eq(0.0)
     end
   end
 
   describe "#to_i" do
     it "should chop off the decimal" do
-      "1,300.05".localize.to_i.should == 1300
-      "1.300,05".localize(:es).to_i.should == 1300
+      expect("1,300.05".localize.to_i).to eq(1300)
+      expect("1.300,05".localize(:es).to_i).to eq(1300)
     end
   end
 
@@ -129,65 +129,65 @@ describe LocalizedString do
     let(:localized_string) { string.localize }
 
     it 'returns a LocalizedString' do
-      localized_string.normalize.should be_an_instance_of(LocalizedString)
+      expect(localized_string.normalize).to be_an_instance_of(LocalizedString)
     end
 
     it 'it uses NFD by default' do
       mock(Eprun).normalize(string, :nfd) { normalized_string }
-      localized_string.normalize.base_obj.should == normalized_string
+      expect(localized_string.normalize.base_obj).to eq(normalized_string)
     end
 
     it "uses specified algorithm if there is any" do
       mock(Eprun).normalize(string, :nfkd) { normalized_string }
-      localized_string.normalize(:using => :NFKD).base_obj.should == normalized_string
+      expect(localized_string.normalize(:using => :NFKD).base_obj).to eq(normalized_string)
     end
 
     it "raises an ArgumentError if passed an unsupported normalization form" do
-      lambda { localized_string.normalize(:using => :blarg) }.should raise_error(ArgumentError)
+      expect { localized_string.normalize(:using => :blarg) }.to raise_error(ArgumentError)
     end
   end
 
   describe "#casefold" do
     it 'returns a LocalizedString' do
       str = "Weißrussland".localize.casefold
-      str.should be_an_instance_of(LocalizedString)
-      str.to_s.should == "weissrussland"
+      expect(str).to be_an_instance_of(LocalizedString)
+      expect(str.to_s).to eq("weissrussland")
     end
 
     it 'does not pass the t option by default' do
-      "Istanbul".localize.casefold.to_s.should == "istanbul"
+      expect("Istanbul".localize.casefold.to_s).to eq("istanbul")
     end
 
     it 'uses the t option when explicitly given' do
-      "Istanbul".localize.casefold(:t => true).to_s.should == "ıstanbul"
+      expect("Istanbul".localize.casefold(:t => true).to_s).to eq("ıstanbul")
     end
 
     it 'uses t by default if the locale is tr (az not supported)' do
-      "Istanbul".localize(:tr).casefold.to_s.should == "ıstanbul"
+      expect("Istanbul".localize(:tr).casefold.to_s).to eq("ıstanbul")
     end
   end
 
   describe "#each_sentence" do
     it "returns an enumerator if not passed a block" do
-      "foo bar".localize.each_sentence.should be_a(Enumerator)
+      expect("foo bar".localize.each_sentence).to be_a(Enumerator)
     end
 
     it "yields sentences as localized strings" do
       str = "Quick. Brown. Fox.".localize
 
       str.each_sentence do |sentence|
-        sentence.should be_a(LocalizedString)
+        expect(sentence).to be_a(LocalizedString)
       end
 
-      str.each_sentence.to_a.map(&:to_s).should == [
+      expect(str.each_sentence.to_a.map(&:to_s)).to eq([
         "Quick.", " Brown.", " Fox."
-      ]
+      ])
     end
   end
 
   describe "#code_points" do
     it "returns an array of Unicode code points for the string" do
-      "español".localize.code_points.should == [0x65, 0x73, 0x70, 0x61, 0xF1, 0x6F, 0x6C]
+      expect("español".localize.code_points).to eq([0x65, 0x73, 0x70, 0x61, 0xF1, 0x6F, 0x6C])
     end
   end
 
@@ -197,34 +197,34 @@ describe LocalizedString do
       str = "twitter"
 
       str.localize.each_char do |char|
-        str.chars.to_a[index].should == char
+        expect(str.chars.to_a[index]).to eq(char)
         index += 1
       end
     end
 
     it "returns an enumerator if no block is given" do
-      "twitter".localize.each_char.should be_a(Enumerator)
+      expect("twitter".localize.each_char).to be_a(Enumerator)
     end
 
     it "responds to a few other methods from Enumerable" do
       upcased = "twitter".localize.map { |letter| letter.upcase }
-      upcased.size.should == 7
-      upcased.join.should == "TWITTER"
+      expect(upcased.size).to eq(7)
+      expect(upcased.join).to eq("TWITTER")
 
-      "twitter".localize.inject("") { |str, letter| str = "#{letter}#{str}"; str }.should == "rettiwt"
+      expect("twitter".localize.inject("") { |str, letter| str = "#{letter}#{str}"; str }).to eq("rettiwt")
     end
   end
 
   describe "#to_yaml" do
     it "should be able to successfully roundtrip the string" do
-      YAML.load("coolio".localize.to_yaml).should == "coolio"
-      YAML.load("coolió".localize.to_yaml).should == "coolió"
+      expect(YAML.load("coolio".localize.to_yaml)).to eq("coolio")
+      expect(YAML.load("coolió".localize.to_yaml)).to eq("coolió")
     end
   end
 
   describe "#to_bidi" do
     it "should return an instance of TwitterCldr::Shared::Bidi" do
-      "abc".localize.to_bidi.should be_a(TwitterCldr::Shared::Bidi)
+      expect("abc".localize.to_bidi).to be_a(TwitterCldr::Shared::Bidi)
     end
   end
 
@@ -232,13 +232,13 @@ describe LocalizedString do
     it "should reverse the order a basic RTL string" do
       str = "{0} \331\210 {1}".gsub("{0}", "a").gsub("{1}", "b")
       chars = str.chars.to_a
-      chars.first.should == "a"
-      chars.last.should == "b"
+      expect(chars.first).to eq("a")
+      expect(chars.last).to eq("b")
 
       result = str.localize.to_reordered_s(:direction => :RTL)
       result_chars = result.chars.to_a
-      result_chars.first.should == "b"
-      result_chars.last.should == "a"
+      expect(result_chars.first).to eq("b")
+      expect(result_chars.last).to eq("a")
     end
   end
 

--- a/spec/localized/localized_symbol_spec.rb
+++ b/spec/localized/localized_symbol_spec.rb
@@ -11,27 +11,27 @@ describe LocalizedSymbol do
 
   describe "#as_language_code" do
     it "returns the correct localized language from the symbol" do
-      :es.localize.as_language_code.should == "Spanish"
+      expect(:es.localize.as_language_code).to eq("Spanish")
       TwitterCldr.locale = :es
-      :es.localize.as_language_code.should == "español"
+      expect(:es.localize.as_language_code).to eq("español")
     end
 
     it "returns nil if the symbol doesn't correspond to a language code" do
-      :blarg.localize.as_language_code.should == nil
+      expect(:blarg.localize.as_language_code).to eq(nil)
     end
 
     it "returns the correct value for mapped as well as CLDR language codes" do
-      :'zh-cn'.localize.as_language_code.should == "Chinese"
-      :'zh-tw'.localize.as_language_code.should == "Traditional Chinese"
-      :'zh-Hant'.localize.as_language_code.should == "Traditional Chinese"
-      :'zh'.localize.as_language_code.should == "Chinese"
+      expect(:'zh-cn'.localize.as_language_code).to eq("Chinese")
+      expect(:'zh-tw'.localize.as_language_code).to eq("Traditional Chinese")
+      expect(:'zh-Hant'.localize.as_language_code).to eq("Traditional Chinese")
+      expect(:'zh'.localize.as_language_code).to eq("Chinese")
     end
   end
 
   describe "#is_rtl?" do
     it "should return true or false depending on the locale" do
-      :es.localize.is_rtl?.should be_false
-      :ar.localize.is_rtl?.should be_true
+      expect(:es.localize.is_rtl?).to be_false
+      expect(:ar.localize.is_rtl?).to be_true
     end
   end
 

--- a/spec/localized/localized_time_spec.rb
+++ b/spec/localized/localized_time_spec.rb
@@ -20,7 +20,7 @@ describe LocalizedTime do
 
     it "should stringify with buddhist calendar" do
       # Ensure that buddhist calendar data is present in th locale.
-      TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist].should_not(
+      expect(TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist]).not_to(
           be_nil, 'buddhist calendar is missing for :th locale (check resources/locales/th/calendars.yml)'
       )
 
@@ -33,7 +33,7 @@ describe LocalizedTime do
 
   describe "#ago" do
     it "should return a localized timespan" do
-      time.localize(:de).ago.should be_a(LocalizedTimespan)
+      expect(time.localize(:de).ago).to be_a(LocalizedTimespan)
     end
   end
 
@@ -42,16 +42,16 @@ describe LocalizedTime do
       date = Date.new(1987, 9, 20)
       time = Time.local(2000, 5, 12, 22, 5)
       datetime = time.localize.to_datetime(date)
-      datetime.should be_a(LocalizedDateTime)
-      datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S").should == "1987-09-20 22:05:00"
+      expect(datetime).to be_a(LocalizedDateTime)
+      expect(datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S")).to eq("1987-09-20 22:05:00")
     end
 
     it "should work with an instance of LocalizedDate too" do
       date = DateTime.new(1987, 9, 20, 0, 0, 0).localize.to_date
       time = Time.local(2000, 5, 12, 22, 5)
       datetime = time.localize.to_datetime(date)
-      datetime.should be_a(LocalizedDateTime)
-      datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S").should == "1987-09-20 22:05:00"
+      expect(datetime).to be_a(LocalizedDateTime)
+      expect(datetime.base_obj.strftime("%Y-%m-%d %H:%M:%S")).to eq("1987-09-20 22:05:00")
     end
   end
 
@@ -59,7 +59,7 @@ describe LocalizedTime do
     it "don't raise errors for any locale" do
       TwitterCldr.supported_locales.each do |locale|
         (CalendarDataReader.types - [:additional]).each do |type|
-          lambda { Time.now.localize(locale).send(:"to_#{type}_s") }.should_not raise_error
+          expect { Time.now.localize(locale).send(:"to_#{type}_s") }.not_to raise_error
         end
       end
     end
@@ -68,9 +68,9 @@ describe LocalizedTime do
   describe "#with_timezone" do
     it "calculates the right time depending on the timezone" do
       time = Time.utc(2000, 5, 12, 22, 5).localize
-      time.to_s.should == "10:05:00 PM"
-      time.with_timezone("America/Los_Angeles").to_s.should == "3:05:00 PM"
-      time.with_timezone("America/New_York").to_s.should == "6:05:00 PM"
+      expect(time.to_s).to eq("10:05:00 PM")
+      expect(time.with_timezone("America/Los_Angeles").to_s).to eq("3:05:00 PM")
+      expect(time.with_timezone("America/New_York").to_s).to eq("6:05:00 PM")
     end
   end
 

--- a/spec/localized/localized_timespan_spec.rb
+++ b/spec/localized/localized_timespan_spec.rb
@@ -10,8 +10,8 @@ include TwitterCldr::Localized
 describe LocalizedTimespan do
   it "should format a numer of seconds in different units" do
     timespan = LocalizedTimespan.new(-172800, :locale => :de)
-    timespan.to_s(:unit => :hour).should match_normalized("Vor 48 Stunden")
-    timespan.to_s(:unit => :day).should match_normalized("Vor 2 Tagen")
+    expect(timespan.to_s(:unit => :hour)).to match_normalized("Vor 48 Stunden")
+    expect(timespan.to_s(:unit => :day)).to match_normalized("Vor 2 Tagen")
   end
 
   it "approximates timespans accurately if explicity asked" do
@@ -37,7 +37,7 @@ describe LocalizedTimespan do
 
     expected.each_pair do |seconds, text|
       timespan = LocalizedTimespan.new(seconds, :locale => :de)
-      timespan.to_s(options).should match_normalized(text)
+      expect(timespan.to_s(options)).to match_normalized(text)
     end
   end
 
@@ -61,7 +61,7 @@ describe LocalizedTimespan do
 
     expected.each_pair do |seconds, text|
       timespan = LocalizedTimespan.new(seconds, :locale => :de)
-      timespan.to_s(options).should match_normalized(text)
+      expect(timespan.to_s(options)).to match_normalized(text)
     end
   end
 
@@ -80,7 +80,7 @@ describe LocalizedTimespan do
       }
 
       expected.each_pair do |unit, text|
-        timespan.to_s(options.merge(:unit => unit)).should match_normalized(text)
+        expect(timespan.to_s(options.merge(:unit => unit))).to match_normalized(text)
       end
     end
   end
@@ -99,7 +99,7 @@ describe LocalizedTimespan do
       }
 
       expected.each_pair do |unit, text|
-        timespan.to_s(:unit => unit).should match_normalized(text)
+        expect(timespan.to_s(:unit => unit)).to match_normalized(text)
       end
     end
   end
@@ -118,7 +118,7 @@ describe LocalizedTimespan do
       }
 
       expected.each_pair do |unit, text|
-        timespan.to_s(:unit => unit).should match_normalized(text)
+        expect(timespan.to_s(:unit => unit)).to match_normalized(text)
       end
     end
   end
@@ -137,7 +137,7 @@ describe LocalizedTimespan do
       }
 
       expected.each_pair do |unit, text|
-        timespan.to_s(options.merge(:unit => unit)).should match_normalized(text)
+        expect(timespan.to_s(options.merge(:unit => unit))).to match_normalized(text)
       end
     end
   end

--- a/spec/normalization_spec.rb
+++ b/spec/normalization_spec.rb
@@ -13,28 +13,28 @@ describe TwitterCldr::Normalization do
 
     it 'it uses NFD by default' do
       mock(Eprun).normalize(string, :nfd) { normalized_string }
-      TwitterCldr::Normalization.normalize(string).should == normalized_string
+      expect(TwitterCldr::Normalization.normalize(string)).to eq(normalized_string)
     end
 
     it "uses specified algorithm if there is any" do
       mock(Eprun).normalize(string, :nfkd) { normalized_string }
-      TwitterCldr::Normalization.normalize(string, :using => :nfkd).should == normalized_string
+      expect(TwitterCldr::Normalization.normalize(string, :using => :nfkd)).to eq(normalized_string)
     end
 
     it "raises an ArgumentError if passed an unsupported normalizer name" do
-      lambda do
+      expect do
         TwitterCldr::Normalization.normalize(string, :using => :blarg)
-      end.should raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it 'accepts normalizer name in upper case' do
       mock(Eprun).normalize(string, :nfkd) { normalized_string }
-      TwitterCldr::Normalization.normalize(string, :using => :NFKD).should == normalized_string
+      expect(TwitterCldr::Normalization.normalize(string, :using => :NFKD)).to eq(normalized_string)
     end
 
     it 'accepts a string' do
       mock(Eprun).normalize(string, :nfkd) { normalized_string }
-      TwitterCldr::Normalization.normalize(string, :using => 'nfkd').should == normalized_string
+      expect(TwitterCldr::Normalization.normalize(string, :using => 'nfkd')).to eq(normalized_string)
     end
 
   end

--- a/spec/parsers/number_parser_spec.rb
+++ b/spec/parsers/number_parser_spec.rb
@@ -16,112 +16,112 @@ describe NumberParser do
 
   describe "#group_separator" do
     it "returns the correct group separator" do
-      @parser.send(:group_separator).should match_normalized(" ")
+      expect(@parser.send(:group_separator)).to match_normalized(" ")
     end
   end
 
   describe "#decimal_separator" do
     it "returns the correct decimal separator" do
-      @parser.send(:decimal_separator).should == ","
+      expect(@parser.send(:decimal_separator)).to eq(",")
     end
   end
 
   describe "#identify" do
     it "properly identifies a numeric value" do
-      @parser.send(:identify, "7841", *separators).should == { :value => "7841", :type => :numeric }
+      expect(@parser.send(:identify, "7841", *separators)).to eq({ :value => "7841", :type => :numeric })
     end
 
     it "properly identifies a decimal separator" do
-      @parser.send(:identify, ",", *separators).should == { :value => ",", :type => :decimal }
+      expect(@parser.send(:identify, ",", *separators)).to eq({ :value => ",", :type => :decimal })
     end
 
     it "properly identifies a group separator" do
-      @parser.send(:identify, ".", *separators).should == { :value => ".", :type => :group }
+      expect(@parser.send(:identify, ".", *separators)).to eq({ :value => ".", :type => :group })
     end
 
     it "returns nil if the text doesn't match a number or either separators" do
-      @parser.send(:identify, "abc", *separators).should == { :value => "abc", :type => nil }
+      expect(@parser.send(:identify, "abc", *separators)).to eq({ :value => "abc", :type => nil })
     end
   end
 
   describe "#tokenize" do
     it "splits text by numericality and group/decimal separators" do
-      @parser.send(:tokenize, "1,33.00", *separators).should == [
+      expect(@parser.send(:tokenize, "1,33.00", *separators)).to eq([
         { :value => "1",  :type => :numeric },
         { :value => ",",  :type => :decimal },
         { :value => "33", :type => :numeric },
         { :value => ".",  :type => :group },
         { :value => "00", :type => :numeric }
-      ]
+      ])
     end
 
     it "returns an empty array for a non-numeric string" do
-      @parser.send(:tokenize, "abc", *separators).should be_empty
+      expect(@parser.send(:tokenize, "abc", *separators)).to be_empty
     end
   end
 
   describe "#separators" do
     it "returns all separators when strict mode is off" do
       group, decimal = @parser.send(:separators, false)
-      group.should == '\.,\s'
-      decimal.should == '\.,\s'
+      expect(group).to eq('\.,\s')
+      expect(decimal).to eq('\.,\s')
     end
 
     it "returns only locale-specific separators when strict mode is on" do
       group, decimal = @parser.send(:separators, true)
-      group.should match_normalized(" ")
-      decimal.should == ','
+      expect(group).to match_normalized(" ")
+      expect(decimal).to eq(',')
     end
   end
 
   describe "#punct_valid" do
     it "correctly validates a number with no decimal" do
       tokens = @parser.send(:tokenize, "1.337", *separators).reject { |t| t[:type] == :numeric }
-      @parser.send(:punct_valid?, tokens).should be_true
+      expect(@parser.send(:punct_valid?, tokens)).to be_true
     end
 
     it "correctly validates a number with a decimal" do
       tokens = @parser.send(:tokenize, "1.337,00", *separators).reject { |t| t[:type] == :numeric }
-      @parser.send(:punct_valid?, tokens).should be_true
+      expect(@parser.send(:punct_valid?, tokens)).to be_true
     end
 
     it "reports on an invalid number when it has more than one decimal" do
       tokens = @parser.send(:tokenize, "1,337,00", *separators).reject { |t| t[:type] == :numeric }
-      @parser.send(:punct_valid?, tokens).should be_false
+      expect(@parser.send(:punct_valid?, tokens)).to be_false
     end
   end
 
   describe "#is_numeric?" do
     it "returns true if the text is numeric" do
-      NumberParser.is_numeric?("4839", "").should be_true
-      NumberParser.is_numeric?("1", "").should be_true
+      expect(NumberParser.is_numeric?("4839", "")).to be_true
+      expect(NumberParser.is_numeric?("1", "")).to be_true
     end
 
     it "returns false if the text is not purely numeric" do
-      NumberParser.is_numeric?("abc", "").should be_false
-      NumberParser.is_numeric?("123abc", "").should be_false
+      expect(NumberParser.is_numeric?("abc", "")).to be_false
+      expect(NumberParser.is_numeric?("123abc", "")).to be_false
     end
 
     it "returns false if the text is blank" do
-      NumberParser.is_numeric?("", "").should be_false
+      expect(NumberParser.is_numeric?("", "")).to be_false
     end
 
     it "accepts the given characters as valid numerics" do
-      NumberParser.is_numeric?("a123a", "a").should be_true
-      NumberParser.is_numeric?("1.234,56").should be_true  # default separator chars used here
+      expect(NumberParser.is_numeric?("a123a", "a")).to be_true
+      expect(NumberParser.is_numeric?("1.234,56")).to be_true  # default separator chars used here
     end
   end
 
   describe "#valid?" do
     it "correctly identifies a series of valid cases" do
       ["5", "5,0", "1.337", "1.337,0", "0,05", ",5", "1.337.000,00"].each do |num|
-        @parser.valid?(num).should be_true
+        expect(@parser.valid?(num)).to be_true
       end
     end
 
     it "correctly identifies a series of invalid cases" do
       ["12,0,0", "5,", "5#{[160].pack("U*")}"].each do |num|
-        @parser.valid?(num).should be_false
+        expect(@parser.valid?(num)).to be_false
       end
     end
   end
@@ -139,49 +139,49 @@ describe NumberParser do
       }
 
       cases.each do |text, expected|
-        @parser.parse(text).should == expected
+        expect(@parser.parse(text)).to eq(expected)
       end
     end
 
     it "correctly raises an error when asked to parse invalid numbers" do
       cases = ["12,0,0", "5,", "5#{[160].pack("U*")}"]
       cases.each do |text|
-        lambda { @parser.parse(text) }.should raise_error(InvalidNumberError)
+        expect { @parser.parse(text) }.to raise_error(InvalidNumberError)
       end
     end
 
     context "non-strict" do
       it "succeeds in parsing even if inexact punctuation is used" do
-        @parser.parse("5 100", :strict => false).should == 5100
+        expect(@parser.parse("5 100", :strict => false)).to eq(5100)
       end
     end
   end
 
   describe "#try_parse" do
     it "parses correctly with a valid number" do
-      @parser.try_parse("1.234").should == 1234
+      expect(@parser.try_parse("1.234")).to eq(1234)
     end
 
     it "parses correctly with a valid number and yields to the given block" do
       pre_result = nil
-      @parser.try_parse("1.234") do |result|
+      expect(@parser.try_parse("1.234") do |result|
         pre_result = result
         9
-      end.should == 9
-      pre_result.should == 1234
+      end).to eq(9)
+      expect(pre_result).to eq(1234)
     end
 
     it "falls back on the default value if the number is invalid" do
-      @parser.try_parse("5,").should be_nil
-      @parser.try_parse("5,", 0).should == 0
+      expect(@parser.try_parse("5,")).to be_nil
+      expect(@parser.try_parse("5,", 0)).to eq(0)
     end
 
     it "falls back on the block if the number is invalid" do
-      @parser.try_parse("5,") { |result| 9 }.should == 9
+      expect(@parser.try_parse("5,") { |result| 9 }).to eq(9)
     end
 
     it "doesn't catch anything but an InvalidNumberError" do
-      lambda { @parser.try_parse(Object.new) }.should raise_error(NoMethodError)
+      expect { @parser.try_parse(Object.new) }.to raise_error(NoMethodError)
     end
   end
 end

--- a/spec/parsers/parser_spec.rb
+++ b/spec/parsers/parser_spec.rb
@@ -32,9 +32,9 @@ describe Parser do
     it "should reset the token index" do
       parser.parse(tokens)
       parser.send(:next_token, :a)
-      parser.send(:current_token).type.should == :b
+      expect(parser.send(:current_token).type).to eq(:b)
       parser.reset
-      parser.send(:current_token).type.should == :a
+      expect(parser.send(:current_token).type).to eq(:a)
     end
   end
 
@@ -42,19 +42,19 @@ describe Parser do
     it "should advance to the next token" do
       parser.parse(tokens)
       parser.send(:next_token, :a)
-      parser.send(:current_token).type.should == :b
+      expect(parser.send(:current_token).type).to eq(:b)
     end
 
     it "should raise an error after encountering an unexpected token" do
       parser.parse(tokens)
-      lambda { parser.send(:next_token, :z) }.should raise_error(UnexpectedTokenError)
+      expect { parser.send(:next_token, :z) }.to raise_error(UnexpectedTokenError)
     end
   end
 
   describe "#current_token" do
     it "returns the current token" do
       parser.parse(tokens)
-      parser.send(:current_token).type.should == :a
+      expect(parser.send(:current_token).type).to eq(:a)
     end
   end
 end

--- a/spec/parsers/segmentation_parser_spec.rb
+++ b/spec/parsers/segmentation_parser_spec.rb
@@ -30,21 +30,21 @@ describe "Segmentation" do
     describe "#parse" do
       it "should parse a rule with a break" do
         rule = parse(tokenize("[a-z] ÷ [0-9]"))
-        rule.left.to_regexp_str.should == "\\A(?:[\\141-\\172])"
-        rule.right.to_regexp_str.should == "\\A(?:[\\60-\\71])"
-        rule.boundary_symbol.should == :break
+        expect(rule.left.to_regexp_str).to eq("\\A(?:[\\141-\\172])")
+        expect(rule.right.to_regexp_str).to eq("\\A(?:[\\60-\\71])")
+        expect(rule.boundary_symbol).to eq(:break)
       end
 
       it "should parse a rule with a non-break" do
         rule = parse(tokenize("[a-z] × [0-9]"))
-        rule.regex.to_regexp_str.should == "\\A(?:[\\141-\\172])(?:[\\60-\\71])"
-        rule.boundary_symbol.should == :no_break
+        expect(rule.regex.to_regexp_str).to eq("\\A(?:[\\141-\\172])(?:[\\60-\\71])")
+        expect(rule.boundary_symbol).to eq(:no_break)
       end
 
       it "should parse a rule containing a variable" do
         rule = parse(tokenize("$FOO × bar"), :symbol_table => symbol_table)
-        rule.regex.to_regexp_str.should == "\\A(?:[\\141-\\143])(?:\\142)(?:\\141)(?:\\162)"
-        rule.boundary_symbol.should == :no_break
+        expect(rule.regex.to_regexp_str).to eq("\\A(?:[\\141-\\143])(?:\\142)(?:\\141)(?:\\162)")
+        expect(rule.boundary_symbol).to eq(:no_break)
       end
     end
   end
@@ -54,19 +54,19 @@ describe "Segmentation" do
       let(:rule) { parse(tokenize("[a-z] ÷ [0-9]")) }
 
       it "rule should be the right type" do
-        rule.should be_a(SegmentationParser::BreakRule)
+        expect(rule).to be_a(SegmentationParser::BreakRule)
       end
 
       it "should match and return the right offset and text" do
         match = rule.match("c7")
-        match.boundary_offset.should == 1
-        match.text.should == "c7"
+        expect(match.boundary_offset).to eq(1)
+        expect(match.text).to eq("c7")
       end
 
       it "should not match if the input string doesn't contain a matching right- and/or left-hand side" do
-        rule.match("C7").should be_nil
-        rule.match("cc").should be_nil
-        rule.match("CC").should be_nil
+        expect(rule.match("C7")).to be_nil
+        expect(rule.match("cc")).to be_nil
+        expect(rule.match("CC")).to be_nil
       end
     end
   end
@@ -76,20 +76,20 @@ describe "Segmentation" do
       let(:rule) { parse(tokenize("[a-z] × [0-9]")) }
 
       it "rule should be the right type" do
-        rule.should be_a(SegmentationParser::NoBreakRule)
+        expect(rule).to be_a(SegmentationParser::NoBreakRule)
       end
 
       it "should match and return the right offset and text" do
         match = rule.match("c7")
         # non-break rules send you to the end of the match (maybe that's wrong?)
-        match.boundary_offset.should == 2
-        match.text.should == "c7"
+        expect(match.boundary_offset).to eq(2)
+        expect(match.text).to eq("c7")
       end
 
       it "should not match if the input string doesn't contain matching text" do
-        rule.match("C7").should be_nil
-        rule.match("cc").should be_nil
-        rule.match("CC").should be_nil
+        expect(rule.match("C7")).to be_nil
+        expect(rule.match("cc")).to be_nil
+        expect(rule.match("CC")).to be_nil
       end
     end
   end

--- a/spec/parsers/symbol_table_spec.rb
+++ b/spec/parsers/symbol_table_spec.rb
@@ -12,13 +12,13 @@ describe SymbolTable do
 
   describe "#fetch" do
     it "should be able to retrieve values for symbols" do
-      table.fetch(:a).should == "b"
+      expect(table.fetch(:a)).to eq("b")
       fetch = lambda { table.fetch(:z) }
 
       if RUBY_VERSION > "1.8.7"
-        fetch.should raise_error(KeyError)
+        expect(fetch).to raise_error(KeyError)
       else
-        fetch.should raise_error(IndexError)
+        expect(fetch).to raise_error(IndexError)
       end
     end
   end
@@ -26,7 +26,7 @@ describe SymbolTable do
   describe "#add" do
     it "should be able to add then fetch new values for symbols" do
       table.add(:e, "f")
-      table.fetch(:e).should == "f"
+      expect(table.fetch(:e)).to eq("f")
     end
   end
 end

--- a/spec/parsers/unicode_regex/character_class_spec.rb
+++ b/spec/parsers/unicode_regex/character_class_spec.rb
@@ -26,22 +26,22 @@ describe UnicodeRegexParser::CharacterClass do
   describe "#to_set" do
     it "unions together char classes with no explicit operator" do
       char_class = char_class_from(parse(tokenize("[[a][b]]")))
-      char_class.to_set.to_a.should == [97..98]
+      expect(char_class.to_set.to_a).to eq([97..98])
     end
 
     it "unions together other entities within char classes when operator is not explicit" do
       char_class = char_class_from(parse(tokenize("[a-z0-9\\u0123]")))
-      char_class.to_set.to_a(true).should == [48..57, 97..122, 291]
+      expect(char_class.to_set.to_a(true)).to eq([48..57, 97..122, 291])
     end
 
     it "intersects correctly" do
       char_class = char_class_from(parse(tokenize("[[a-m]&[g-z]]")))
-      char_class.to_set.to_a.should == [103..109]
+      expect(char_class.to_set.to_a).to eq([103..109])
     end
 
     it "finds symmetric differences correctly" do
       char_class = char_class_from(parse(tokenize("[[a-m]-[g-z]]")))
-      char_class.to_set.to_a.should == [97..102, 110..122]
+      expect(char_class.to_set.to_a).to eq([97..102, 110..122])
     end
 
     it "computes sets for nested expressions" do
@@ -51,67 +51,67 @@ describe UnicodeRegexParser::CharacterClass do
       # = (104..122) subtr ()
       # = (104..122)
       char_class = char_class_from(parse(tokenize("[[[a-m]&[h-j]]-[k-z]]")))
-      char_class.to_set.to_a.should == [104..122]
+      expect(char_class.to_set.to_a).to eq([104..122])
     end
 
     it "pulls in ranges for unicode character sets" do
       char_class = char_class_from(parse(tokenize("[\\p{Zs}]")))
-      char_class.to_set.to_a(true).should == [
+      expect(char_class.to_set.to_a(true)).to eq([
         32, 160, 5760, 6158, 8192..8202, 8239, 8287, 12288
-      ]
+      ])
     end
 
     it "computes unions between unicode character sets" do
       char_class = char_class_from(parse(tokenize("[[\\p{Zs}][\\p{Cc}]]")))
-      char_class.to_set.to_a(true).should == [
+      expect(char_class.to_set.to_a(true)).to eq([
         0..1, 8..32, 127..160, 5760, 6158, 8192..8202, 8239, 8287, 12288
-      ]
+      ])
     end
 
     it "computes intersections between unicode character sets" do
       char_class = char_class_from(parse(tokenize("[[\\p{Zs}]&[\\u2000-\\u202B]]")))
-      char_class.to_set.to_a(true).should == [8192..8202]
+      expect(char_class.to_set.to_a(true)).to eq([8192..8202])
     end
 
     it "supports negating character sets" do
       char_class = char_class_from(parse(tokenize("[^\\u2000-\\u202B]")))
-      char_class.to_set.to_a(true).should == [
+      expect(char_class.to_set.to_a(true)).to eq([
         0..1, 8..8191, 8236..55295, 57344..1114111
-      ]
+      ])
     end
 
     it "supports literal and escaped characters" do
       char_class = char_class_from(parse(tokenize("[abc\\edf\\g]")))
-      char_class.to_set.to_a(true).should == [97..103]
+      expect(char_class.to_set.to_a(true)).to eq([97..103])
     end
 
     it "supports special switch characters" do
       char_class = char_class_from(parse(tokenize("[\\w]")))  # a-z, A-Z, 0-9, _
-      char_class.to_set.to_a(true).should == [48..57, 65..90, 95, 97..122]
+      expect(char_class.to_set.to_a(true)).to eq([48..57, 65..90, 95, 97..122])
     end
 
     it "supports negated switch characters" do
       char_class = char_class_from(parse(tokenize("[\\D]")))  # i.e. NOT \w
-      char_class.to_set.to_a(true).should == [
+      expect(char_class.to_set.to_a(true)).to eq([
         0..1, 8..47, 58..55295, 57344..1114111
-      ]
+      ])
     end
   end
 
   describe "#to_regexp_str" do
     it "wraps ranges in square brackets" do
       char_class = char_class_from(parse(tokenize("[a-z]")))
-      char_class.to_regexp_str.should == "(?:[\\141-\\172])"
+      expect(char_class.to_regexp_str).to eq("(?:[\\141-\\172])")
     end
 
     it "octal-encodes and wraps sequential characters to isolate bytes" do
       char_class = char_class_from(parse(tokenize("[{foo}]")))
-      char_class.to_regexp_str.should == "(?:(?:\\146)(?:\\157)(?:\\157))"
+      expect(char_class.to_regexp_str).to eq("(?:(?:\\146)(?:\\157)(?:\\157))")
     end
 
     it "combines multiple components with 'or' pipe characters" do
       char_class = char_class_from(parse(tokenize("[{foo}abc]")))
-      char_class.to_regexp_str.should == "(?:(?:\\146)(?:\\157)(?:\\157)|[\\141-\\143])"
+      expect(char_class.to_regexp_str).to eq("(?:(?:\\146)(?:\\157)(?:\\157)|[\\141-\\143])")
     end
   end
 end

--- a/spec/parsers/unicode_regex/character_range_spec.rb
+++ b/spec/parsers/unicode_regex/character_range_spec.rb
@@ -15,7 +15,7 @@ describe UnicodeRegexParser::CharacterRange do
         UnicodeRegexParser::UnicodeString.new([98])
       )
 
-      range.to_set.to_a(true).should == [97..98]
+      expect(range.to_set.to_a(true)).to eq([97..98])
     end
   end
 end

--- a/spec/parsers/unicode_regex/character_set_spec.rb
+++ b/spec/parsers/unicode_regex/character_set_spec.rb
@@ -11,26 +11,26 @@ describe UnicodeRegexParser::CharacterSet do
   describe "#to_set" do
     it "should return a set containing codepoints for the given general property" do
       char_set = UnicodeRegexParser::CharacterSet.new("Zs")
-      char_set.to_set.to_a(true).should == [
+      expect(char_set.to_set.to_a(true)).to eq([
         32, 160, 5760, 6158, 8192..8202, 8239, 8287, 12288
-      ]
+      ])
     end
 
     it "should return a set containing codepoints for the given named property" do
       char_set = UnicodeRegexParser::CharacterSet.new("Sentence_Break=Sp")
-      char_set.to_set.to_a(true).should == [
+      expect(char_set.to_set.to_a(true)).to eq([
         9, 11..12, 32, 160, 5760, 8192..8202, 8239, 8287, 12288
-      ]
+      ])
     end
 
     it "should raise an exception when given an invalid property name or value" do
-      lambda do
+      expect do
         UnicodeRegexParser::CharacterSet.new("Foobar=Sp").to_set
-      end.should raise_error(UnicodeRegexParserError)
+      end.to raise_error(UnicodeRegexParserError)
 
-      lambda do
+      expect do
         UnicodeRegexParser::CharacterSet.new("Sentence_Break=Foo").to_set
-      end.should raise_error(UnicodeRegexParserError)
+      end.to raise_error(UnicodeRegexParserError)
     end
   end
 end

--- a/spec/parsers/unicode_regex/literal_spec.rb
+++ b/spec/parsers/unicode_regex/literal_spec.rb
@@ -11,24 +11,24 @@ describe UnicodeRegexParser::Literal do
   describe "#to_set" do
     it "should return literal characters as codepoints" do
       literal = UnicodeRegexParser::Literal.new("a")
-      literal.to_set.to_a(true).should == [97]
+      expect(literal.to_set.to_a(true)).to eq([97])
     end
 
     it "should return escaped characters with no special meaning as codepoints" do
       literal = UnicodeRegexParser::Literal.new("\\a")
-      literal.to_set.to_a(true).should == [97]
+      expect(literal.to_set.to_a(true)).to eq([97])
     end
 
     it "should convert special regex switches to their range equivalents" do
       literal = UnicodeRegexParser::Literal.new("\\d")  # digit
-      literal.to_set.to_a(true).should == [48..57]
+      expect(literal.to_set.to_a(true)).to eq([48..57])
     end
 
     it "should convert negated special regex switches to their range equivalents" do
       literal = UnicodeRegexParser::Literal.new("\\D")  # NOT digit
-      literal.to_set.to_a(true).should == [
+      expect(literal.to_set.to_a(true)).to eq([
         0..1, 8..47, 58..55295, 57344..1114111
-      ]
+      ])
     end
   end
 end

--- a/spec/parsers/unicode_regex/unicode_string_spec.rb
+++ b/spec/parsers/unicode_regex/unicode_string_spec.rb
@@ -11,12 +11,12 @@ describe UnicodeRegexParser::UnicodeString do
   describe "#to_set" do
     it "should return a zero-length range when representing a single codepoint" do
       str = UnicodeRegexParser::UnicodeString.new([97])
-      str.to_set.to_a.should == [97..97]
+      expect(str.to_set.to_a).to eq([97..97])
     end
 
     it "should return a range containing the codepoint array as both the first and last elements" do
       str = UnicodeRegexParser::UnicodeString.new([97, 98, 99])
-      str.to_set.to_a.should == [[97, 98, 99]..[97, 98, 99]]
+      expect(str.to_set.to_a).to eq([[97, 98, 99]..[97, 98, 99]])
     end
   end
 end

--- a/spec/parsers/unicode_regex_parser_spec.rb
+++ b/spec/parsers/unicode_regex_parser_spec.rb
@@ -23,64 +23,64 @@ describe UnicodeRegexParser do
   describe "#parse" do
     it "identifies ranges" do
       elements = parse(tokenize("[a-z]"))
-      elements.first.should be_a(UnicodeRegexParser::CharacterClass)
+      expect(elements.first).to be_a(UnicodeRegexParser::CharacterClass)
       root = elements.first.send(:root)
-      root.should be_a(UnicodeRegexParser::CharacterRange)
-      root.initial.codepoints.should == "a".unpack("U*")
-      root.final.codepoints.should == "z".unpack("U*")
+      expect(root).to be_a(UnicodeRegexParser::CharacterRange)
+      expect(root.initial.codepoints).to eq("a".unpack("U*"))
+      expect(root.final.codepoints).to eq("z".unpack("U*"))
     end
 
     it "replaces variables" do
       symbol_table = SymbolTable.new("$VAR" => tokenize("\\p{L}"))
       elements = parse(tokenize("($VAR)?"), :symbol_table => symbol_table)
-      elements[1].should be_a(UnicodeRegexParser::CharacterSet)
-      elements[1].property_value.should == "L"
+      expect(elements[1]).to be_a(UnicodeRegexParser::CharacterSet)
+      expect(elements[1].property_value).to eq("L")
     end
 
     it "handles character and negated character sets" do
       elements = parse(tokenize("\\p{L}[:^P:]\\P{L}[:P:]"))
 
       element = elements[0]
-      element.should be_a(UnicodeRegexParser::CharacterSet)
-      element.property_value.should == "L"
+      expect(element).to be_a(UnicodeRegexParser::CharacterSet)
+      expect(element.property_value).to eq("L")
 
       element = elements[1]
-      element.should be_a(UnicodeRegexParser::CharacterClass)
-      element.send(:root).child.property_value.should == "P"
-      element.send(:root).operator.should == :negate
+      expect(element).to be_a(UnicodeRegexParser::CharacterClass)
+      expect(element.send(:root).child.property_value).to eq("P")
+      expect(element.send(:root).operator).to eq(:negate)
 
       element = elements[2]
-      element.should be_a(UnicodeRegexParser::CharacterClass)
-      element.send(:root).child.property_value.should == "L"
+      expect(element).to be_a(UnicodeRegexParser::CharacterClass)
+      expect(element.send(:root).child.property_value).to eq("L")
 
       element = elements[3]
-      element.should be_a(UnicodeRegexParser::CharacterSet)
-      element.property_value.should == "P"
+      expect(element).to be_a(UnicodeRegexParser::CharacterSet)
+      expect(element.property_value).to eq("P")
     end
 
     it "handles unicode characters" do
       elements = parse(tokenize("\\u0123"))
-      elements[0].should be_a(UnicodeRegexParser::UnicodeString)
-      elements[0].codepoints.should == [291]
+      expect(elements[0]).to be_a(UnicodeRegexParser::UnicodeString)
+      expect(elements[0].codepoints).to eq([291])
     end
 
     it "handles multichar and escaped unicode strings" do
       elements = parse(tokenize("\\g{abc}"))
-      elements[0].should be_a(UnicodeRegexParser::Literal)
-      elements[0].text.should == "\\g"
-      elements[1].should be_a(UnicodeRegexParser::UnicodeString)
-      elements[1].codepoints.should == [97, 98, 99]
+      expect(elements[0]).to be_a(UnicodeRegexParser::Literal)
+      expect(elements[0].text).to eq("\\g")
+      expect(elements[1]).to be_a(UnicodeRegexParser::UnicodeString)
+      expect(elements[1].codepoints).to eq([97, 98, 99])
     end
 
     it "handles special chars" do
       elements = parse(tokenize("^(?:)$"))
-      elements.each { |elem| elem.should be_a(UnicodeRegexParser::Literal) }
-      elements[0].text.should == "^"
-      elements[1].text.should == "("
-      elements[2].text.should == "?"
-      elements[3].text.should == ":"
-      elements[4].text.should == ")"
-      elements[5].text.should == "$"
+      elements.each { |elem| expect(elem).to be_a(UnicodeRegexParser::Literal) }
+      expect(elements[0].text).to eq("^")
+      expect(elements[1].text).to eq("(")
+      expect(elements[2].text).to eq("?")
+      expect(elements[3].text).to eq(":")
+      expect(elements[4].text).to eq(")")
+      expect(elements[5].text).to eq("$")
     end
   end
 end

--- a/spec/resources/loader_spec.rb
+++ b/spec/resources/loader_spec.rb
@@ -16,37 +16,37 @@ describe Loader do
 
     it 'loads the correct YAML file' do
       stub_resource_file(resource_path, "---\n- 1\n- 2\n")
-      loader.get_resource(:random, :resource).should == [1, 2]
+      expect(loader.get_resource(:random, :resource)).to eq([1, 2])
     end
 
     it 'symbolizes hash keys' do
       stub_resource_file(resource_path, "---\n:a:\n  :b: 3\n")
-      loader.get_resource(:random, :resource).should == { :a => { :b => 3 } }
+      expect(loader.get_resource(:random, :resource)).to eq({ :a => { :b => 3 } })
     end
 
     it 'loads the resource only once' do
       mock(loader).load_resource(resource_path).once { resource_content }
 
       result = loader.get_resource(:random, :resource)
-      result.should == resource_content
+      expect(result).to eq(resource_content)
       # second time load_resource is not called but we get the same object as before
-      loader.get_resource(:random, :resource).object_id.should == result.object_id
+      expect(loader.get_resource(:random, :resource).object_id).to eq(result.object_id)
     end
 
     it 'accepts a variable length resource path both in symbols and strings' do
       stub(loader).load_resource('foo/bar/baz.yml') { 'foo-bar-baz' }
-      loader.get_resource('foo', :bar, 'baz').should == 'foo-bar-baz'
+      expect(loader.get_resource('foo', :bar, 'baz')).to eq('foo-bar-baz')
     end
 
     it 'raises an exception if resource file is missing' do
       mock(File).file?(File.join(TwitterCldr::RESOURCES_DIR, 'foo/bar.yml')) { false }
-      lambda { loader.get_resource(:foo, :bar) }.should raise_error(ArgumentError, "Resource 'foo/bar.yml' not found.")
+      expect { loader.get_resource(:foo, :bar) }.to raise_error(ArgumentError, "Resource 'foo/bar.yml' not found.")
     end
 
     context 'custom resources' do
       it "doesn't merge the custom resource if it doesn't exist" do
         mock(loader).read_resource_file('foo/bar.yml') { ":foo: bar" }
-        loader.get_resource(:foo, :bar).should == { :foo => "bar" }
+        expect(loader.get_resource(:foo, :bar)).to eq({ :foo => "bar" })
       end
 
       context 'with a custom resource' do
@@ -61,12 +61,12 @@ describe Loader do
           mock.proxy(loader).load_resource("foo/bar.yml")
           mock.proxy(loader).load_resource("custom/foo/bar.yml", false)
 
-          loader.get_resource(:foo, :bar).should == { :foo => "bar", :bar => "baz" }
+          expect(loader.get_resource(:foo, :bar)).to eq({ :foo => "bar", :bar => "baz" })
         end
 
         it 'does not merge the custom resource if custom resources are disabled' do
           TwitterCldr.disable_custom_locale_resources = true
-          loader.get_resource(:foo, :bar).should == { :foo => "bar" }
+          expect(loader.get_resource(:foo, :bar)).to eq({ :foo => "bar" })
           TwitterCldr.disable_custom_locale_resources = false
         end
       end
@@ -76,7 +76,7 @@ describe Loader do
   describe '#get_locale_resource' do
     it 'loads the correct locale resource file' do
       stub(loader).get_resource(:locales, :de, :numbers) { 'foo' }
-      loader.get_locale_resource(:de, :numbers).should == 'foo'
+      expect(loader.get_locale_resource(:de, :numbers)).to eq('foo')
     end
 
     it 'loads the resource only once' do
@@ -84,56 +84,56 @@ describe Loader do
 
       result = loader.get_locale_resource(:de, :numbers)
       # second time get_resource is not called but we get the same object as before
-      loader.get_locale_resource(:de, :numbers).object_id.should == result.object_id
+      expect(loader.get_locale_resource(:de, :numbers).object_id).to eq(result.object_id)
     end
 
     it 'converts locales' do
       mock(TwitterCldr).convert_locale('zh-tw') { :'zh-Hant' }
       mock(loader).get_resource(:locales, :'zh-Hant', :numbers) { 'foo' }
 
-      loader.get_locale_resource('zh-tw', :numbers).should == 'foo'
+      expect(loader.get_locale_resource('zh-tw', :numbers)).to eq('foo')
     end
   end
 
   describe '#resource_loaded' do
     it 'should return true if the resource is cached, false otherwise' do
       loader.preload_resources_for_locale(:de, :numbers)
-      loader.resource_loaded?(:locales, :de, :numbers).should be_true
-      loader.resource_loaded?(:locales, :de, :calendars).should be_false
+      expect(loader.resource_loaded?(:locales, :de, :numbers)).to be_true
+      expect(loader.resource_loaded?(:locales, :de, :calendars)).to be_false
     end
   end
 
   describe '#locale_resource_loaded' do
     it 'should return true if the locale resource is cached, false otherwise' do
       loader.preload_resources_for_locale(:de, :numbers)
-      loader.locale_resource_loaded?(:de, :numbers).should be_true
-      loader.locale_resource_loaded?(:de, :calendars).should be_false
+      expect(loader.locale_resource_loaded?(:de, :numbers)).to be_true
+      expect(loader.locale_resource_loaded?(:de, :calendars)).to be_false
     end
   end
 
   describe '#resource_types' do
     it 'returns the list of available resource types' do
       types = loader.resource_types
-      types.should be_a(Array)
-      types.should include(:calendars)
-      types.should include(:numbers)
-      types.should include(:units)
+      expect(types).to be_a(Array)
+      expect(types).to include(:calendars)
+      expect(types).to include(:numbers)
+      expect(types).to include(:units)
     end
   end
 
   describe '#preload_resources_for_locale' do
     it 'loads potentially multiple resources into the cache' do
       loader.preload_resources_for_locale(:ar, :calendars, :units)
-      loader.locale_resource_loaded?(:ar, :calendars).should be_true
-      loader.locale_resource_loaded?(:ar, :units).should be_true
-      loader.locale_resource_loaded?(:en, :units).should be_false
+      expect(loader.locale_resource_loaded?(:ar, :calendars)).to be_true
+      expect(loader.locale_resource_loaded?(:ar, :units)).to be_true
+      expect(loader.locale_resource_loaded?(:en, :units)).to be_false
     end
 
     it 'loads all resources for the locale if the :all resource type is specified' do
       loader.preload_resources_for_locale(:ar, :all)
       loader.resource_types.each do |resource_type|
-        loader.locale_resource_loaded?(:ar, resource_type).should be_true
-        loader.locale_resource_loaded?(:en, resource_type).should be_false
+        expect(loader.locale_resource_loaded?(:ar, resource_type)).to be_true
+        expect(loader.locale_resource_loaded?(:en, resource_type)).to be_false
       end
     end
   end
@@ -141,9 +141,9 @@ describe Loader do
   describe '#preload_resource_for_locales' do
     it 'loads a single resource for potentially multiple locales into the cache' do
       loader.preload_resource_for_locales(:calendars, :sv, :bn)
-      loader.locale_resource_loaded?(:sv, :calendars).should be_true
-      loader.locale_resource_loaded?(:bn, :calendars).should be_true
-      loader.locale_resource_loaded?(:sv, :units).should be_false
+      expect(loader.locale_resource_loaded?(:sv, :calendars)).to be_true
+      expect(loader.locale_resource_loaded?(:bn, :calendars)).to be_true
+      expect(loader.locale_resource_loaded?(:sv, :units)).to be_false
     end
   end
 
@@ -151,9 +151,9 @@ describe Loader do
     it 'loads potentially multiple resources for all locales' do
       loader.preload_resources_for_all_locales(:plurals, :lists)
       TwitterCldr.supported_locales.each do |locale|
-        loader.locale_resource_loaded?(locale, :plurals).should be_true
-        loader.locale_resource_loaded?(locale, :lists).should be_true
-        loader.locale_resource_loaded?(locale, :calendars).should be_false
+        expect(loader.locale_resource_loaded?(locale, :plurals)).to be_true
+        expect(loader.locale_resource_loaded?(locale, :lists)).to be_true
+        expect(loader.locale_resource_loaded?(locale, :calendars)).to be_false
       end
     end
   end
@@ -163,7 +163,7 @@ describe Loader do
       loader.preload_all_resources
       TwitterCldr.supported_locales.each do |locale|
         loader.resource_types.each do |resource_type|
-          loader.locale_resource_loaded?(locale, resource_type).should be_true
+          expect(loader.locale_resource_loaded?(locale, resource_type)).to be_true
         end
       end
     end

--- a/spec/shared/break_iterator_spec.rb
+++ b/spec/shared/break_iterator_spec.rb
@@ -12,47 +12,47 @@ describe BreakIterator do
     let(:iterator) { BreakIterator.new(:en, :use_uli_exceptions => true) }
 
     it "should return an enumerator if called without a block" do
-      iterator.each_sentence("foo bar").should be_a(Enumerator)
+      expect(iterator.each_sentence("foo bar")).to be_a(Enumerator)
     end
 
     it "splits a simple string into sentences" do
       str = "The. Quick. Brown. Fox."
-      iterator.each_sentence(str).to_a.should == [
+      expect(iterator.each_sentence(str).to_a).to eq([
         "The.", " Quick.", " Brown.", " Fox."
-      ]
+      ])
     end
 
     it "does not split on commas, for example" do
       str = "The. Quick, brown. Fox."
-      iterator.each_sentence(str).to_a.should == [
+      expect(iterator.each_sentence(str).to_a).to eq([
         "The.", " Quick, brown.", " Fox."
-      ]
+      ])
     end
 
     it "does not split periods in the midst of other letters, eg. in a URL" do
       str = "Visit us. Go to http://translate.twitter.com."
-      iterator.each_sentence(str).to_a.should == [
+      expect(iterator.each_sentence(str).to_a).to eq([
         "Visit us.",
         " Go to http://translate.twitter.com."
-      ]
+      ])
     end
 
     it "splits on sentences that end with other kinds of punctuation" do
       str = "Help us translate! Speak another language? You really, really rock."
-      iterator.each_sentence(str).to_a.should == [
+      expect(iterator.each_sentence(str).to_a).to eq([
         "Help us translate!",
         " Speak another language?",
         " You really, really rock."
-      ]
+      ])
     end
 
     context "with ULI exceptions" do
       it "does not split on certain abbreviations like Mr. and Mrs." do
         str = "I really like Mrs. Patterson. She's nice."
-        iterator.each_sentence(str).to_a.should == [
+        expect(iterator.each_sentence(str).to_a).to eq([
           "I really like Mrs. Patterson.",
           " She's nice."
-        ]
+        ])
       end
     end
 
@@ -61,11 +61,11 @@ describe BreakIterator do
 
       it "splits on certain abbreviations like Mr. and Mrs. (use ULI rules to avoid this behavior)" do
         str = "I really like Mrs. Patterson. She's nice."
-        iterator.each_sentence(str).to_a.should == [
+        expect(iterator.each_sentence(str).to_a).to eq([
           "I really like Mrs.",
           " Patterson.",
           " She's nice."
-        ]
+        ])
       end
     end
   end

--- a/spec/shared/calendar_spec.rb
+++ b/spec/shared/calendar_spec.rb
@@ -22,20 +22,20 @@ describe Calendar do
       stub(TwitterCldr).locale { :fr }
       cal = Calendar.new
 
-      cal.locale.should == :fr
-      cal.calendar_type.should == TwitterCldr::DEFAULT_CALENDAR_TYPE
+      expect(cal.locale).to eq(:fr)
+      expect(cal.calendar_type).to eq(TwitterCldr::DEFAULT_CALENDAR_TYPE)
     end
 
     it 'returns calendar for a specific locale' do
-      Calendar.new(:jp).locale.should == :jp
+      expect(Calendar.new(:jp).locale).to eq(:jp)
     end
 
     it 'uses TwitterCldr.convert_locale' do
-      Calendar.new(:'zh-cn').locale.should == :zh
+      expect(Calendar.new(:'zh-cn').locale).to eq(:zh)
     end
 
     it 'returns calendar of a specific type' do
-      Calendar.new(:th, :buddhist).calendar_type.should == :buddhist
+      expect(Calendar.new(:th, :buddhist).calendar_type).to eq(:buddhist)
     end
 
   end
@@ -43,35 +43,35 @@ describe Calendar do
   describe '#months' do
     context 'when data is available' do
       it 'returns months list in a wide names form by default' do
-        calendar.months.should == %w[Januar Februar März April Mai Juni Juli August September Oktober November Dezember]
+        expect(calendar.months).to eq(%w[Januar Februar März April Mai Juni Juli August September Oktober November Dezember])
       end
 
       it 'supports wide names form' do
-        calendar.months(:wide).should == %w[Januar Februar März April Mai Juni Juli August September Oktober November Dezember]
+        expect(calendar.months(:wide)).to eq(%w[Januar Februar März April Mai Juni Juli August September Oktober November Dezember])
       end
 
       it 'supports narrow names form' do
-        calendar.months(:narrow).should == %w[J F M A M J J A S O N D]
+        expect(calendar.months(:narrow)).to eq(%w[J F M A M J J A S O N D])
       end
 
       it 'supports abbreviated names form' do
-        calendar.months(:abbreviated).should == %w[Jan Feb Mär Apr Mai Jun Jul Aug Sep Okt Nov Dez]
+        expect(calendar.months(:abbreviated)).to eq(%w[Jan Feb Mär Apr Mai Jun Jul Aug Sep Okt Nov Dez])
       end
 
       it 'returns nil if invalid names form is passed' do
-        calendar.months(:wat).should == nil
+        expect(calendar.months(:wat)).to eq(nil)
       end
     end
 
     context 'when some data is missing' do
       it 'returns nil if some names format is missing' do
         stub(TwitterCldr).get_locale_resource { { :de => { :calendars => { :gregorian => { :months => { :'stand-alone' => {} } } } } } }
-        calendar.months(:wide).should == nil
+        expect(calendar.months(:wide)).to eq(nil)
       end
 
       it 'returns nil if calendars data is missing' do
         stub(TwitterCldr).get_locale_resource { { :de => {} } }
-        calendar.months(:wide).should == nil
+        expect(calendar.months(:wide)).to eq(nil)
       end
     end
   end
@@ -79,7 +79,7 @@ describe Calendar do
   describe '#weekdays' do
     context 'when data is available' do
       it 'returns weekdays list in a wide names form by default' do
-        calendar.weekdays.should == {
+        expect(calendar.weekdays).to eq({
             :sun => 'Sonntag',
             :mon => 'Montag',
             :tue => 'Dienstag',
@@ -87,11 +87,11 @@ describe Calendar do
             :thu => 'Donnerstag',
             :fri => 'Freitag',
             :sat => 'Samstag'
-        }
+        })
       end
 
       it 'supports wide names form' do
-        calendar.weekdays(:wide).should == {
+        expect(calendar.weekdays(:wide)).to eq({
             :sun => 'Sonntag',
             :mon => 'Montag',
             :tue => 'Dienstag',
@@ -99,15 +99,15 @@ describe Calendar do
             :thu => 'Donnerstag',
             :fri => 'Freitag',
             :sat => 'Samstag'
-        }
+        })
       end
 
       it 'supports narrow names form' do
-        calendar.weekdays(:narrow).should == { :sun => 'S', :mon => 'M', :tue => 'D', :wed => 'M', :thu => 'D', :fri => 'F', :sat => 'S' }
+        expect(calendar.weekdays(:narrow)).to eq({ :sun => 'S', :mon => 'M', :tue => 'D', :wed => 'M', :thu => 'D', :fri => 'F', :sat => 'S' })
       end
 
       it 'supports abbreviated names form' do
-        calendar.weekdays(:abbreviated).should == {
+        expect(calendar.weekdays(:abbreviated)).to eq({
             :sun => 'So',
             :mon => 'Mo',
             :tue => 'Di',
@@ -115,23 +115,23 @@ describe Calendar do
             :thu => 'Do',
             :fri => 'Fr',
             :sat => 'Sa'
-        }
+        })
       end
 
       it 'returns nil if invalid names form is passed' do
-        calendar.weekdays(:wat).should == nil
+        expect(calendar.weekdays(:wat)).to eq(nil)
       end
     end
 
     context 'when some data is missing' do
       it 'returns nil if some names format is missing' do
         stub(TwitterCldr).get_locale_resource { { :de => { :calendars => { :gregorian => { :days => { :'stand-alone' => {} } } } } } }
-        calendar.weekdays(:wide).should == nil
+        expect(calendar.weekdays(:wide)).to eq(nil)
       end
 
       it 'returns nil if calendars data is missing' do
         stub(TwitterCldr).get_locale_resource { { :de => {} } }
-        calendar.weekdays(:wide).should == nil
+        expect(calendar.weekdays(:wide)).to eq(nil)
       end
     end
   end
@@ -139,117 +139,117 @@ describe Calendar do
   describe '#fields' do
     it 'returns the list of fields for the locale (eg. weekday, month, etc)' do
       fields = calendar.fields
-      fields[:hour].should match_normalized("Stunde")
-      fields[:dayperiod].should match_normalized("Tageshälfte")
-      fields[:weekday].should match_normalized("Wochentag")
+      expect(fields[:hour]).to match_normalized("Stunde")
+      expect(fields[:dayperiod]).to match_normalized("Tageshälfte")
+      expect(fields[:weekday]).to match_normalized("Wochentag")
 
       fields = Calendar.new(:ja).fields
-      fields[:hour].should match_normalized("時")
-      fields[:dayperiod].should match_normalized("午前/午後")
-      fields[:weekday].should match_normalized("曜日")
+      expect(fields[:hour]).to match_normalized("時")
+      expect(fields[:dayperiod]).to match_normalized("午前/午後")
+      expect(fields[:weekday]).to match_normalized("曜日")
     end
   end
 
   describe '#quarters' do
     it 'returns default quarters' do
-      calendar.quarters.should == {
+      expect(calendar.quarters).to eq({
         1 => "1. Quartal",
         2 => "2. Quartal",
         3 => "3. Quartal",
         4 => "4. Quartal"
-      }
+      })
     end
 
     it 'returns quarters with other name forms' do
-      calendar.quarters(:abbreviated).should == {
+      expect(calendar.quarters(:abbreviated)).to eq({
         1 => "Q1", 2 => "Q2",
         3 => "Q3", 4 => "Q4"
-      }
+      })
 
-      calendar.quarters(:narrow).should == {
+      expect(calendar.quarters(:narrow)).to eq({
         1 => 1, 2 => 2,
         3 => 3, 4 => 4
-      }
+      })
     end
   end
 
   describe '#periods' do
     it 'returns default periods' do
       periods = calendar.periods
-      periods[:am].should == "vorm."
-      periods[:pm].should == "nachm."
+      expect(periods[:am]).to eq("vorm.")
+      expect(periods[:pm]).to eq("nachm.")
     end
 
     it 'returns quarters with other name forms' do
       periods = calendar.periods(:abbreviated)
-      periods[:am].should == "vorm."
-      periods[:pm].should == "nachm."
+      expect(periods[:am]).to eq("vorm.")
+      expect(periods[:pm]).to eq("nachm.")
     end
   end
 
   describe '#eras' do
     it 'returns default eras' do
-      calendar.eras.should == {
+      expect(calendar.eras).to eq({
         0 => "vor der gewöhnlichen Zeitrechnung",
         1 => "der gewöhnlichen Zeitrechnung"
-      }
+      })
     end
 
     it 'returns eras with other name forms' do
-      calendar.eras(:abbr).should == {
+      expect(calendar.eras(:abbr)).to eq({
         0 => "v. u. Z.",
         1 => "u. Z."
-      }
+      })
     end
   end
 
   describe '#date_order' do
     it 'should return the correct date order for a few different locales' do
-      Calendar.new(:en).date_order.should == [:month, :day, :year]
-      Calendar.new(:ja).date_order.should == [:year, :month, :day]
-      Calendar.new(:ar).date_order.should == [:day, :month, :year]
+      expect(Calendar.new(:en).date_order).to eq([:month, :day, :year])
+      expect(Calendar.new(:ja).date_order).to eq([:year, :month, :day])
+      expect(Calendar.new(:ar).date_order).to eq([:day, :month, :year])
     end
   end
 
   describe '#time_order' do
     it 'should return the correct time order for a few different locales' do
-      Calendar.new(:en).time_order.should == [:hour, :minute, :second, :period]
-      Calendar.new(:ja).time_order.should == [:hour, :minute, :second]
-      Calendar.new(:ar).time_order.should == [:hour, :minute, :second, :period]
+      expect(Calendar.new(:en).time_order).to eq([:hour, :minute, :second, :period])
+      expect(Calendar.new(:ja).time_order).to eq([:hour, :minute, :second])
+      expect(Calendar.new(:ar).time_order).to eq([:hour, :minute, :second, :period])
     end
   end
 
   describe '#datetime_order' do
     it 'should return the correct date and time order for a few different locales' do
-      Calendar.new(:en).datetime_order.should == [:month, :day, :year, :hour, :minute, :second, :period]
-      Calendar.new(:ja).datetime_order.should == [:year, :month, :day, :hour, :minute, :second]
-      Calendar.new(:ar).datetime_order.should == [:day, :month, :year, :hour, :minute, :second, :period]
+      expect(Calendar.new(:en).datetime_order).to eq([:month, :day, :year, :hour, :minute, :second, :period])
+      expect(Calendar.new(:ja).datetime_order).to eq([:year, :month, :day, :hour, :minute, :second])
+      expect(Calendar.new(:ar).datetime_order).to eq([:day, :month, :year, :hour, :minute, :second, :period])
     end
   end
 
   describe '#methods_for_tokens' do
     it 'converts pattern tokens into their corresponding method names' do
       tokens = [TwitterCldr::Tokenizers::Token.new(:value => "YYYY", :type => :pattern)]
-      calendar.send(:methods_for_tokens, tokens).should == [:year_of_week_of_year]
+      expect(calendar.send(:methods_for_tokens, tokens)).to eq([:year_of_week_of_year])
     end
 
     it 'ignores plaintext tokens' do
       tokens = [TwitterCldr::Tokenizers::Token.new(:value => "blarg", :type => :plaintext)]
-      calendar.send(:methods_for_tokens, tokens).should == []
+      expect(calendar.send(:methods_for_tokens, tokens)).to eq([])
     end
   end
 
   describe '#resolve_methods' do
     it 'converts certain method names to their basic equivalents' do
-      calendar.send(:resolve_methods, [:year_of_week_of_year]).should == [:year]
-      calendar.send(:resolve_methods, [:weekday_local]).should == [:weekday]
-      calendar.send(:resolve_methods, [:day_of_month, :second_fraction]).should == [:day, :second]
+      expect(calendar.send(:resolve_methods, [:year_of_week_of_year])).to eq([:year])
+      expect(calendar.send(:resolve_methods, [:weekday_local])).to eq([:weekday])
+      expect(calendar.send(:resolve_methods, [:day_of_month, :second_fraction])).to eq([:day, :second])
     end
 
     it 'does not convert basic method names' do
-      calendar.send(:resolve_methods, [:year]).should == [:year]
-      calendar.send(:resolve_methods, [:day, :month]).should == [:day, :month]
-      calendar.send(:resolve_methods, [:minute, :hour, :second]).should == [:minute, :hour, :second]
+      expect(calendar.send(:resolve_methods, [:year])).to eq([:year])
+      expect(calendar.send(:resolve_methods, [:day, :month])).to eq([:day, :month])
+      expect(calendar.send(:resolve_methods, [:minute, :hour, :second])).to eq([:minute, :hour, :second])
     end
   end
 

--- a/spec/shared/casefolder_spec.rb
+++ b/spec/shared/casefolder_spec.rb
@@ -10,13 +10,13 @@ include TwitterCldr::Shared
 describe Casefolder do
   describe "#casefold" do
     it "should casefold a few canonical examples" do
-      Casefolder.casefold("Weißrussland").should == "weissrussland"
-      Casefolder.casefold("Hello, World").should == "hello, world"
+      expect(Casefolder.casefold("Weißrussland")).to eq("weissrussland")
+      expect(Casefolder.casefold("Hello, World")).to eq("hello, world")
     end
 
     it "should correctly casefold the Turkic i character" do
-      Casefolder.casefold("Istanbul", true).should == "ıstanbul"
-      Casefolder.casefold("İstanbul", true).should == "istanbul"
+      expect(Casefolder.casefold("Istanbul", true)).to eq("ıstanbul")
+      expect(Casefolder.casefold("İstanbul", true)).to eq("istanbul")
     end
 
     # the files used in this test come from the unicode_utils gem
@@ -24,7 +24,7 @@ describe Casefolder do
       base_path = File.dirname(__FILE__)
       text = File.read(File.join(base_path, "casefolding.txt"))
       expected = File.read(File.join(base_path, "casefolding_expected.txt"))
-      Casefolder.casefold(text).should == expected
+      expect(Casefolder.casefold(text)).to eq(expected)
     end
   end
 end

--- a/spec/shared/code_point_spec.rb
+++ b/spec/shared/code_point_spec.rb
@@ -26,15 +26,15 @@ describe CodePoint do
       let(:decomposition) { '0028 007A 0029' }
 
       it 'parses decomposition mapping' do
-        code_point.decomposition.should == [0x28, 0x7A, 0x29]
+        expect(code_point.decomposition).to eq([0x28, 0x7A, 0x29])
       end
 
       it 'initializes compatibility tag as nil' do
-        code_point.compatibility_decomposition_tag.should be_nil
+        expect(code_point.compatibility_decomposition_tag).to be_nil
       end
 
       it 'returns false from compatibility_decomposition?' do
-        code_point.should_not be_compatibility_decomposition
+        expect(code_point).not_to be_compatibility_decomposition
       end
     end
 
@@ -42,15 +42,15 @@ describe CodePoint do
       let(:decomposition) { '<font> 0028 007A 0029' }
 
       it 'parses decomposition mapping' do
-        code_point.decomposition.should == [0x28, 0x7A, 0x29]
+        expect(code_point.decomposition).to eq([0x28, 0x7A, 0x29])
       end
 
       it 'initializes compatibility decomposition tag' do
-        code_point.compatibility_decomposition_tag.should == 'font'
+        expect(code_point.compatibility_decomposition_tag).to eq('font')
       end
 
       it 'returns true from compatibility_decomposition?' do
-        code_point.should be_compatibility_decomposition
+        expect(code_point).to be_compatibility_decomposition
       end
     end
 
@@ -58,15 +58,15 @@ describe CodePoint do
       let(:decomposition) { '' }
 
       it 'parses decomposition mapping' do
-        code_point.decomposition.should be_nil
+        expect(code_point.decomposition).to be_nil
       end
 
       it 'initializes compatibility tag as nil' do
-        code_point.compatibility_decomposition_tag.should be_nil
+        expect(code_point.compatibility_decomposition_tag).to be_nil
       end
 
       it 'returns false from compatibility_decomposition?' do
-        code_point.should_not be_compatibility_decomposition
+        expect(code_point).not_to be_compatibility_decomposition
       end
     end
   end
@@ -74,12 +74,12 @@ describe CodePoint do
   describe "#find" do
     it "retrieves information for any valid code point" do
       data = CodePoint.find(0x301)
-      data.should be_a(CodePoint)
-      data.fields.length.should == 15
+      expect(data).to be_a(CodePoint)
+      expect(data.fields.length).to eq(15)
     end
 
     it "returns nil if the information is not found" do
-      CodePoint.find(0xFFFFFFF).should be_nil
+      expect(CodePoint.find(0xFFFFFFF)).to be_nil
     end
 
     it "fetches valid information for the specified code point" do
@@ -106,9 +106,9 @@ describe CodePoint do
       test_data.each do |code_point, data|
         cp_data = CodePoint.find(code_point)
 
-        cp_data.should_not be_nil
+        expect(cp_data).not_to be_nil
 
-        [:code_point, :name, :category, :combining_class].map { |msg| cp_data.send(msg) }.should == data[0..3]
+        expect([:code_point, :name, :category, :combining_class].map { |msg| cp_data.send(msg) }).to eq(data[0..3])
       end
     end
   end
@@ -116,32 +116,32 @@ describe CodePoint do
   describe "#code_points_for{index}" do
     it "returns code points for the given general unicode property name" do
       cps = CodePoint.code_points_for_category(:Cc)
-      cps.should be_a(Array)
-      cps.first.should == (0..31)
+      expect(cps).to be_a(Array)
+      expect(cps.first).to eq(0..31)
 
       cps = CodePoint.code_points_for_bidi_class(:BN)
-      cps.should be_a(Array)
-      cps.first.should == (0..8)
+      expect(cps).to be_a(Array)
+      expect(cps.first).to eq(0..8)
 
       cps = CodePoint.code_points_for_bidi_mirrored(:N)
-      cps.should be_a(Array)
-      cps.first.should == (0..39)
+      expect(cps).to be_a(Array)
+      expect(cps.first).to eq(0..39)
     end
   end
 
   describe "#code_points_for_property_value" do
     it "returns code points for the given unicode property and value" do
       cps = CodePoint.code_points_for_line_break(:CM)
-      cps.should be_a(Array)
-      cps.first.should == (0..8)
+      expect(cps).to be_a(Array)
+      expect(cps.first).to eq(0..8)
 
       cps = CodePoint.code_points_for_sentence_break(:Extend)
-      cps.should be_a(Array)
-      cps.first.should == (768..879)
+      expect(cps).to be_a(Array)
+      expect(cps.first).to eq(768..879)
 
       cps = CodePoint.code_points_for_word_break(:Hebrew_Letter)
-      cps.should be_a(Array)
-      cps.first.should == (1488..1514)
+      expect(cps).to be_a(Array)
+      expect(cps.first).to eq(1488..1514)
     end
   end
 
@@ -158,18 +158,18 @@ describe CodePoint do
       end
 
       it "should return a code point with the correct value" do
-        CodePoint.for_canonical_decomposition([123, 456]).should == "I'm code point 789"
+        expect(CodePoint.for_canonical_decomposition([123, 456])).to eq("I'm code point 789")
       end
 
       it "should return nil if no decomposition mapping exists" do
-        CodePoint.for_canonical_decomposition([987]).should be_nil
+        expect(CodePoint.for_canonical_decomposition([987])).to be_nil
       end
     end
 
     it "should cache the decomposition map" do
       mock(TwitterCldr).get_resource(:unicode_data, :canonical_compositions) { canonical_compositions }.once
-      CodePoint.for_canonical_decomposition([0xA0]).should be_nil
-      CodePoint.for_canonical_decomposition([0xA0]).should be_nil
+      expect(CodePoint.for_canonical_decomposition([0xA0])).to be_nil
+      expect(CodePoint.for_canonical_decomposition([0xA0])).to be_nil
     end
   end
 
@@ -186,29 +186,29 @@ describe CodePoint do
     end
 
     it "returns nil if not part of a hangul block" do
-      CodePoint.hangul_type(100).should == nil
+      expect(CodePoint.hangul_type(100)).to eq(nil)
     end
 
     it "returns the correct part (i.e. lpart, vpart, or tpart) before composition or decomposition" do
-      CodePoint.hangul_type(5).should  == :lparts
-      CodePoint.hangul_type(30).should == :vparts
-      CodePoint.hangul_type(41).should == :tparts
+      expect(CodePoint.hangul_type(5)).to  eq(:lparts)
+      expect(CodePoint.hangul_type(30)).to eq(:vparts)
+      expect(CodePoint.hangul_type(41)).to eq(:tparts)
     end
 
     it "returns composition if no part can be found" do
-      CodePoint.hangul_type(11).should == :compositions
+      expect(CodePoint.hangul_type(11)).to eq(:compositions)
     end
   end
 
   describe "#excluded_from_composition?" do
     it "excludes anything in the list of ranges" do
       stub(CodePoint).composition_exclusions { [10..10, 13..14, 20..30] }
-      CodePoint.excluded_from_composition?(10).should be_true
-      CodePoint.excluded_from_composition?(13).should be_true
-      CodePoint.excluded_from_composition?(14).should be_true
-      CodePoint.excluded_from_composition?(15).should be_false
-      CodePoint.excluded_from_composition?(19).should be_false
-      CodePoint.excluded_from_composition?(100).should be_false
+      expect(CodePoint.excluded_from_composition?(10)).to be_true
+      expect(CodePoint.excluded_from_composition?(13)).to be_true
+      expect(CodePoint.excluded_from_composition?(14)).to be_true
+      expect(CodePoint.excluded_from_composition?(15)).to be_false
+      expect(CodePoint.excluded_from_composition?(19)).to be_false
+      expect(CodePoint.excluded_from_composition?(100)).to be_false
     end
   end
 
@@ -219,21 +219,21 @@ describe CodePoint do
 
     it "finds the block that corresponds to the code point" do
       stub(TwitterCldr).get_resource(:unicode_data, :blocks) { [[:klingon, 122..307], [:hirogen, 1337..2200]] }
-      CodePoint.send(:get_block, 200).should  == [:klingon, 122..307]
-      CodePoint.send(:get_block, 2199).should == [:hirogen, 1337..2200]
-      CodePoint.send(:get_block, 100).should be_nil
+      expect(CodePoint.send(:get_block, 200)).to  eq([:klingon, 122..307])
+      expect(CodePoint.send(:get_block, 2199)).to eq([:hirogen, 1337..2200])
+      expect(CodePoint.send(:get_block, 100)).to be_nil
     end
   end
 
   describe "#get_range_start" do
     it "returns the data for a non-explicit range" do
       block_data = { 0x1337 => [0x1337, "<CJK Ideograph Extension A, First>"] }
-      CodePoint.send(:get_range_start, 0xABC, block_data).should == [0xABC, "<CJK Ideograph Extension A>"]
+      expect(CodePoint.send(:get_range_start, 0xABC, block_data)).to eq([0xABC, "<CJK Ideograph Extension A>"])
     end
 
     it "returns nil if the block data doesn't contain a non-explicit range" do
       block_data = { 0x1337 => [0x1337, "<CJK Ideograph Extension A>"] }
-      CodePoint.send(:get_range_start, 0xABC, block_data).should == nil
+      expect(CodePoint.send(:get_range_start, 0xABC, block_data)).to eq(nil)
     end
   end
 end

--- a/spec/shared/currencies_spec.rb
+++ b/spec/shared/currencies_spec.rb
@@ -15,16 +15,16 @@ describe Currencies do
     it "should list all supported country codes" do
       codes = Currencies.currency_codes
 
-      codes.size.should == 297
-      codes.should include(*TEST_CODES)
+      expect(codes.size).to eq(297)
+      expect(codes).to include(*TEST_CODES)
     end
   end
 
   describe "#for_code" do
     it "should return all information for PEN" do
       data = Currencies.for_code("PEN")
-      data.should be_a(Hash)
-      data.should include(
+      expect(data).to be_a(Hash)
+      expect(data).to include(
         :name        => "Peruvian nuevo sol",
         :currency    => :PEN,
         :symbol      => "S/.",
@@ -34,8 +34,8 @@ describe Currencies do
 
     it "should return all information for CAD, a currency code with multiple possible symbols" do
       data = Currencies.for_code("CAD")
-      data.should be_a(Hash)
-      data.should include(
+      expect(data).to be_a(Hash)
+      expect(data).to include(
         :name        => "Canadian dollar",
         :currency    => :CAD,
         :symbol      => "$",
@@ -46,7 +46,7 @@ describe Currencies do
     it "verifies that all code_points values are equivalent to their corresponding symbols" do
       Currencies.currency_codes.select do |code|
         data = Currencies.for_code(code)
-        data[:code_points].pack("U*").should == data[:symbol]
+        expect(data[:code_points].pack("U*")).to eq(data[:symbol])
       end
     end
   end

--- a/spec/shared/language_codes_spec.rb
+++ b/spec/shared/language_codes_spec.rb
@@ -12,79 +12,79 @@ describe LanguageCodes do
     let(:languages) { LanguageCodes.languages }
 
     it 'returns an array' do
-      languages.should be_instance_of(Array)
+      expect(languages).to be_instance_of(Array)
     end
 
     it 'returns symbols' do
-      languages.each { |language| language.should be_instance_of(Symbol) }
+      languages.each { |language| expect(language).to be_instance_of(Symbol) }
     end
 
     it 'returns supported languages' do
-      languages.should include(:Spanish, :English, :Russian, :Japanese, :Basque)
+      expect(languages).to include(:Spanish, :English, :Russian, :Japanese, :Basque)
     end
   end
 
   describe '#valid_standard?' do
     it 'returns true if the standard is valid' do
-      LanguageCodes.valid_standard?(:iso_639_2).should be_true
+      expect(LanguageCodes.valid_standard?(:iso_639_2)).to be_true
     end
 
     it 'returns false if the standard is invalid' do
-      LanguageCodes.valid_standard?(:iso_639).should be_false
+      expect(LanguageCodes.valid_standard?(:iso_639)).to be_false
     end
 
     it 'accepts a string' do
-      LanguageCodes.valid_standard?('iso_639_2').should be_true
+      expect(LanguageCodes.valid_standard?('iso_639_2')).to be_true
     end
   end
 
   describe '#valid_code?' do
     it 'returns true if the code is present in the given standard' do
-      LanguageCodes.valid_code?(:spa, :iso_639_2).should be_true
+      expect(LanguageCodes.valid_code?(:spa, :iso_639_2)).to be_true
     end
 
     it 'returns false if the code is not present in the given standard' do
-      LanguageCodes.valid_code?(:foo, :iso_639_2).should be_false
+      expect(LanguageCodes.valid_code?(:foo, :iso_639_2)).to be_false
     end
 
     it 'raises exception if the standard is invalid' do
-      lambda { LanguageCodes.valid_code?(:es, :foobar) }.should raise_exception(ArgumentError, ':foobar is not a valid standard name')
+      expect { LanguageCodes.valid_code?(:es, :foobar) }.to raise_exception(ArgumentError, ':foobar is not a valid standard name')
     end
 
     it 'accepts strings' do
-      LanguageCodes.valid_code?('spa', 'iso_639_2').should be_true
+      expect(LanguageCodes.valid_code?('spa', 'iso_639_2')).to be_true
     end
   end
 
   describe '#convert' do
     it 'converts codes between different standards' do
-      LanguageCodes.convert(:Spanish, :from => :name,      :to => :bcp_47   ).should == :es
-      LanguageCodes.convert(:es,      :from => :bcp_47,    :to => :iso_639_1).should == :es
-      LanguageCodes.convert(:es,      :from => :iso_639_1, :to => :iso_639_2).should == :spa
-      LanguageCodes.convert(:spa,     :from => :iso_639_2, :to => :iso_639_3).should == :spa
-      LanguageCodes.convert(:spa,     :from => :iso_639_3, :to => :name     ).should == :Spanish
+      expect(LanguageCodes.convert(:Spanish, :from => :name,      :to => :bcp_47   )).to eq(:es)
+      expect(LanguageCodes.convert(:es,      :from => :bcp_47,    :to => :iso_639_1)).to eq(:es)
+      expect(LanguageCodes.convert(:es,      :from => :iso_639_1, :to => :iso_639_2)).to eq(:spa)
+      expect(LanguageCodes.convert(:spa,     :from => :iso_639_2, :to => :iso_639_3)).to eq(:spa)
+      expect(LanguageCodes.convert(:spa,     :from => :iso_639_3, :to => :name     )).to eq(:Spanish)
     end
 
     it 'converts from terminology iso_639_2 codes' do
-      LanguageCodes.convert(:hye, :from => :iso_639_2, :to => :bcp_47).should == :hy
+      expect(LanguageCodes.convert(:hye, :from => :iso_639_2, :to => :bcp_47)).to eq(:hy)
     end
 
     it 'converts from alternative bcp_47 codes' do
-      LanguageCodes.convert('ar-adf', :from => :bcp_47, :to => :iso_639_3).should == :adf
+      expect(LanguageCodes.convert('ar-adf', :from => :bcp_47, :to => :iso_639_3)).to eq(:adf)
     end
 
     it 'returns nil if conversion data is missing' do
-      LanguageCodes.convert(:bsq, :from => :bcp_47, :to => :iso_639_1).should be_nil
-      LanguageCodes.convert(:FooBar, :from => :name, :to => :iso_639_1).should be_nil
+      expect(LanguageCodes.convert(:bsq, :from => :bcp_47, :to => :iso_639_1)).to be_nil
+      expect(LanguageCodes.convert(:FooBar, :from => :name, :to => :iso_639_1)).to be_nil
     end
 
     it 'accepts strings' do
-      LanguageCodes.convert('Spanish', 'from' => 'name', 'to' => 'bcp_47').should == :es
+      expect(LanguageCodes.convert('Spanish', 'from' => 'name', 'to' => 'bcp_47')).to eq(:es)
     end
 
     it 'raises exception if :from or :to options are missing' do
       [[:es, { :to => :bcp_47 }], [:es, { :from => :bcp_47 }], [:es]].each do |args|
-        lambda { LanguageCodes.convert(*args) }.should raise_exception(ArgumentError, "options :from and :to are required")
+        expect { LanguageCodes.convert(*args) }.to raise_exception(ArgumentError, "options :from and :to are required")
       end
     end
 
@@ -94,36 +94,36 @@ describe LanguageCodes do
           [:es, { :from => :bcp_47, :to => :foobar }],
           [:es, { :from => :foobar, :to => :foobar }]
       ].each do |args|
-        lambda { LanguageCodes.convert(*args) }.should raise_exception(ArgumentError, ':foobar is not a valid standard name')
+        expect { LanguageCodes.convert(*args) }.to raise_exception(ArgumentError, ':foobar is not a valid standard name')
       end
     end
   end
 
   describe '#from_language' do
     it 'returns language code by language name' do
-      LanguageCodes.from_language(:Spanish, :iso_639_2).should == :spa
+      expect(LanguageCodes.from_language(:Spanish, :iso_639_2)).to eq(:spa)
     end
 
     it 'accepts strings' do
-      LanguageCodes.from_language('Spanish', 'iso_639_2').should == :spa
+      expect(LanguageCodes.from_language('Spanish', 'iso_639_2')).to eq(:spa)
     end
 
     it 'raises exception when standard is invalid' do
-      lambda { LanguageCodes.from_language(:Spanish, :foobar) }.should raise_exception(':foobar is not a valid standard name')
+      expect { LanguageCodes.from_language(:Spanish, :foobar) }.to raise_exception(':foobar is not a valid standard name')
     end
   end
 
   describe '#to_language' do
     it 'returns language name as a string by language code' do
-      LanguageCodes.to_language(:es, :iso_639_1).should == 'Spanish'
+      expect(LanguageCodes.to_language(:es, :iso_639_1)).to eq('Spanish')
     end
 
     it 'accepts strings' do
-      LanguageCodes.to_language('es', 'iso_639_1').should == 'Spanish'
+      expect(LanguageCodes.to_language('es', 'iso_639_1')).to eq('Spanish')
     end
 
     it 'raises exception when standard is invalid' do
-      lambda { LanguageCodes.to_language(:es, :foobar) }.should raise_exception(':foobar is not a valid standard name')
+      expect { LanguageCodes.to_language(:es, :foobar) }.to raise_exception(':foobar is not a valid standard name')
     end
   end
 
@@ -131,15 +131,15 @@ describe LanguageCodes do
     let(:spanish_standards) { [:bcp_47, :iso_639_1, :iso_639_2, :iso_639_3] }
 
     it 'returns an array of standards that are available for conversion from a given code' do
-      LanguageCodes.standards_for(:es, :bcp_47).should =~ spanish_standards
+      expect(LanguageCodes.standards_for(:es, :bcp_47)).to match_array(spanish_standards)
     end
 
     it 'accepts string' do
-      LanguageCodes.standards_for('es', 'bcp_47').should =~ spanish_standards
+      expect(LanguageCodes.standards_for('es', 'bcp_47')).to match_array(spanish_standards)
     end
 
     it 'raises exception when standard is invalid' do
-      lambda { LanguageCodes.standards_for(:es, :foobar) }.should raise_exception(':foobar is not a valid standard name')
+      expect { LanguageCodes.standards_for(:es, :foobar) }.to raise_exception(':foobar is not a valid standard name')
     end
   end
 
@@ -147,15 +147,15 @@ describe LanguageCodes do
     let(:spanish_standards) { [:bcp_47, :iso_639_1, :iso_639_2, :iso_639_3] }
 
     it 'returns an array of standards that have a code for a given language' do
-      LanguageCodes.standards_for_language(:Spanish).should =~ spanish_standards
+      expect(LanguageCodes.standards_for_language(:Spanish)).to match_array(spanish_standards)
     end
 
     it 'accepts string' do
-      LanguageCodes.standards_for_language('Spanish').should =~ spanish_standards
+      expect(LanguageCodes.standards_for_language('Spanish')).to match_array(spanish_standards)
     end
 
     it 'returns empty array for unknown languages' do
-      LanguageCodes.standards_for_language('FooBar').should == []
+      expect(LanguageCodes.standards_for_language('FooBar')).to eq([])
     end
   end
 end

--- a/spec/shared/languages_spec.rb
+++ b/spec/shared/languages_spec.rb
@@ -10,98 +10,98 @@ include TwitterCldr::Shared
 describe Languages do
   describe "#translate_language" do
     it "should translate a language from one locale to another" do
-      Languages.translate_language("Russian", :en, :es).should match_normalized("ruso")
-      Languages.translate_language("ruso", :es, :en).should match_normalized("Russian")
-      Languages.translate_language("Spanish", :en, :es).should match_normalized("español")
-      Languages.translate_language("ruso", :es, :ru).should match_normalized("русский")
+      expect(Languages.translate_language("Russian", :en, :es)).to match_normalized("ruso")
+      expect(Languages.translate_language("ruso", :es, :en)).to match_normalized("Russian")
+      expect(Languages.translate_language("Spanish", :en, :es)).to match_normalized("español")
+      expect(Languages.translate_language("ruso", :es, :ru)).to match_normalized("русский")
     end
 
     it "should be capitalization agnostic" do
-      Languages.translate_language("russian", :en, :es).should match_normalized("ruso")
-      Languages.translate_language("RUSSIAN", :en, :es).should match_normalized("ruso")
+      expect(Languages.translate_language("russian", :en, :es)).to match_normalized("ruso")
+      expect(Languages.translate_language("RUSSIAN", :en, :es)).to match_normalized("ruso")
     end
 
     it "defaults the destination language to English (or whatever the global locale is)" do
-      Languages.translate_language("Ruso", :es).should match_normalized("Russian")
-      Languages.translate_language("русский", :ru).should match_normalized("Russian")
+      expect(Languages.translate_language("Ruso", :es)).to match_normalized("Russian")
+      expect(Languages.translate_language("русский", :ru)).to match_normalized("Russian")
     end
 
     it "defaults source and destination language to English if not given" do
-      Languages.translate_language("Russian").should match_normalized("Russian")
+      expect(Languages.translate_language("Russian")).to match_normalized("Russian")
       TwitterCldr.locale = :es
-      Languages.translate_language("Russian").should match_normalized("ruso")
+      expect(Languages.translate_language("Russian")).to match_normalized("ruso")
     end
 
     it "successfully translates locale codes that are and are not in the CLDR using the locale map" do
-      Languages.translate_language("Russian", :en, :'zh-cn').should match_normalized("俄文")
-      Languages.translate_language("Russian", :en, :'zh').should match_normalized("俄文")
+      expect(Languages.translate_language("Russian", :en, :'zh-cn')).to match_normalized("俄文")
+      expect(Languages.translate_language("Russian", :en, :'zh')).to match_normalized("俄文")
     end
 
     it "should return nil if no translation was found" do
-      Languages.translate_language("Russian", :en, :blarg).should == nil
+      expect(Languages.translate_language("Russian", :en, :blarg)).to eq(nil)
     end
   end
 
   describe "#from_code_for_locale" do
     it "should return the language in the correct locale for the given locale code (i.e. es in English should be Spanish)" do
-      Languages.from_code_for_locale(:es, :en).should match_normalized("Spanish")
-      Languages.from_code_for_locale(:en, :es).should match_normalized("inglés")
+      expect(Languages.from_code_for_locale(:es, :en)).to match_normalized("Spanish")
+      expect(Languages.from_code_for_locale(:en, :es)).to match_normalized("inglés")
     end
   end
 
   describe "#from_code" do
     it "should return the language in the default locale for the given locale code" do
-      Languages.from_code(:es).should match_normalized("Spanish")
-      Languages.from_code(:ru).should match_normalized("Russian")
+      expect(Languages.from_code(:es)).to match_normalized("Spanish")
+      expect(Languages.from_code(:ru)).to match_normalized("Russian")
       TwitterCldr.locale = :es
-      Languages.from_code(:es).should match_normalized("español")
+      expect(Languages.from_code(:es)).to match_normalized("español")
     end
   end
 
   describe "#all_for" do
     it "should return a hash of all languages for the given language code" do
       langs = Languages.all_for(:es)
-      langs.should be_a(Hash)
-      langs[:ru].should match_normalized("ruso")
+      expect(langs).to be_a(Hash)
+      expect(langs[:ru]).to match_normalized("ruso")
     end
 
     it "should return an empty hash for an invalid language" do
       langs = Languages.all_for(:blarg)
-      langs.should == {}
+      expect(langs).to eq({})
     end
   end
 
   describe "#all" do
     it "should use the default language to get the language hash" do
       langs = Languages.all
-      langs.should be_a(Hash)
-      langs[:ru].should match_normalized("Russian")
-      langs[:de].should match_normalized("German")
+      expect(langs).to be_a(Hash)
+      expect(langs[:ru]).to match_normalized("Russian")
+      expect(langs[:de]).to match_normalized("German")
 
       TwitterCldr.locale = :es
       langs = Languages.all
-      langs.should be_a(Hash)
-      langs[:ru].should match_normalized("ruso")
-      langs[:de].should match_normalized("alemán")
+      expect(langs).to be_a(Hash)
+      expect(langs[:ru]).to match_normalized("ruso")
+      expect(langs[:de]).to match_normalized("alemán")
     end
   end
 
   describe "#is_rtl?" do
     it "should return true for certain locales" do
       [:ar, :he, :ur, :fa].each do |locale|
-        Languages.is_rtl?(locale).should be_true
+        expect(Languages.is_rtl?(locale)).to be_true
       end
     end
 
     it "should return false for certain locales" do
       [:en, :es, :hu, :ja].each do |locale|
-        Languages.is_rtl?(locale).should be_false
+        expect(Languages.is_rtl?(locale)).to be_false
       end
     end
 
     it "should not raise errors for any locale" do
       TwitterCldr.supported_locales.each do |locale|
-        lambda { Languages.is_rtl?(locale) }.should_not raise_error
+        expect { Languages.is_rtl?(locale) }.not_to raise_error
       end
     end
   end

--- a/spec/shared/numbering_system_spec.rb
+++ b/spec/shared/numbering_system_spec.rb
@@ -10,12 +10,12 @@ include TwitterCldr::Shared
 describe NumberingSystem do
   describe "#for_name" do
     it "should return the correct numbering system for the given name" do
-      NumberingSystem.for_name("latn").digits.should == %w(0 1 2 3 4 5 6 7 8 9)
-      NumberingSystem.for_name("arab").digits.should == %w(٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩)
+      expect(NumberingSystem.for_name("latn").digits).to eq(%w(0 1 2 3 4 5 6 7 8 9))
+      expect(NumberingSystem.for_name("arab").digits).to eq(%w(٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩))
     end
 
     it "should raise an error if the system is not numeric" do
-      lambda { NumberingSystem.for_name("roman") }.should raise_error(UnsupportedNumberingSystemError)
+      expect { NumberingSystem.for_name("roman") }.to raise_error(UnsupportedNumberingSystemError)
     end
   end
 
@@ -24,8 +24,8 @@ describe NumberingSystem do
       let(:system) { NumberingSystem.for_name("arab") }
 
       it "replaces ascii numeral characters with arabic ones" do
-        system.transliterate(123).should match_normalized("١٢٣")
-        system.transliterate(947).should match_normalized("٩٤٧")
+        expect(system.transliterate(123)).to match_normalized("١٢٣")
+        expect(system.transliterate(947)).to match_normalized("٩٤٧")
       end
     end
 
@@ -33,8 +33,8 @@ describe NumberingSystem do
       let(:system) { NumberingSystem.for_name("hanidec") }
 
       it "replaces ascii numeral characters with Han ones" do
-        system.transliterate(123).should match_normalized("一二三")
-        system.transliterate(947).should match_normalized("九四七")
+        expect(system.transliterate(123)).to match_normalized("一二三")
+        expect(system.transliterate(947)).to match_normalized("九四七")
       end
     end
   end

--- a/spec/shared/numbers_spec.rb
+++ b/spec/shared/numbers_spec.rb
@@ -14,22 +14,22 @@ describe Numbers do
     it 'returns numerical symbols for default locale' do
       stub(TwitterCldr).locale { :jp }
       stub(TwitterCldr).get_locale_resource(:jp, :numbers) { { :jp => { :numbers => { :symbols => symbols } } } }
-      TwitterCldr::Shared::Numbers.symbols.should == symbols
+      expect(TwitterCldr::Shared::Numbers.symbols).to eq(symbols)
     end
 
     it 'returns numerical symbols for default locale' do
       stub(TwitterCldr).get_locale_resource(:np, :numbers) { { :np => { :numbers => { :symbols => symbols } } } }
-      TwitterCldr::Shared::Numbers.symbols(:np).should == symbols
+      expect(TwitterCldr::Shared::Numbers.symbols(:np)).to eq(symbols)
     end
 
     it 'converts locale' do
       stub(TwitterCldr).get_locale_resource(:'zh-Hant', :numbers) { { :'zh-Hant' => { :numbers => { :symbols => symbols } } } }
-      TwitterCldr::Shared::Numbers.symbols('zh-tw').should == symbols
+      expect(TwitterCldr::Shared::Numbers.symbols('zh-tw')).to eq(symbols)
     end
 
     it 'returns nil if the resource is missing' do
       stub(TwitterCldr).get_locale_resource(:nop, :numbers) { nil }
-      TwitterCldr::Shared::Numbers.symbols(:nop).should be_nil
+      expect(TwitterCldr::Shared::Numbers.symbols(:nop)).to be_nil
     end
   end
 end

--- a/spec/shared/phone_codes_spec.rb
+++ b/spec/shared/phone_codes_spec.rb
@@ -12,15 +12,15 @@ describe PhoneCodes do
     let(:territories) { PhoneCodes.territories }
 
     it 'returns an array' do
-      territories.should be_instance_of(Array)
+      expect(territories).to be_instance_of(Array)
     end
 
     it 'returns symbols' do
-      territories.each { |territory| territory.should be_instance_of(Symbol) }
+      territories.each { |territory| expect(territory).to be_instance_of(Symbol) }
     end
 
     it 'returns supported territories' do
-      territories.should include(:br, :fr, :jp)
+      expect(territories).to include(:br, :fr, :jp)
     end
   end
 
@@ -31,19 +31,19 @@ describe PhoneCodes do
     before(:each) { mock(PhoneCodes).resource { { territory => code } } }
 
     it 'returns phone code for a given territory' do
-      PhoneCodes.code_for_territory(territory).should == code
+      expect(PhoneCodes.code_for_territory(territory)).to eq(code)
     end
 
     it 'returns nil if the regex is missing' do
-      PhoneCodes.code_for_territory(:foo).should be_nil
+      expect(PhoneCodes.code_for_territory(:foo)).to be_nil
     end
 
     it 'accepts strings' do
-      PhoneCodes.code_for_territory(territory.to_s).should == code
+      expect(PhoneCodes.code_for_territory(territory.to_s)).to eq(code)
     end
 
     it 'accepts upper-case strings' do
-      PhoneCodes.code_for_territory(territory.to_s.upcase).should == code
+      expect(PhoneCodes.code_for_territory(territory.to_s.upcase)).to eq(code)
     end
   end
 end

--- a/spec/shared/postal_codes_spec.rb
+++ b/spec/shared/postal_codes_spec.rb
@@ -12,15 +12,15 @@ describe PostalCodes do
     let(:territories) { PostalCodes.territories }
 
     it 'returns an array' do
-      territories.should be_instance_of(Array)
+      expect(territories).to be_instance_of(Array)
     end
 
     it 'returns symbols' do
-      territories.each { |territory| territory.should be_instance_of(Symbol) }
+      territories.each { |territory| expect(territory).to be_instance_of(Symbol) }
     end
 
     it 'returns supported territories' do
-      territories.should include(:br, :fr, :jp)
+      expect(territories).to include(:br, :fr, :jp)
     end
   end
 
@@ -31,19 +31,19 @@ describe PostalCodes do
     before(:each) { mock(PostalCodes).resource { { territory => regex } } }
 
     it 'returns postal code regex for a given territory' do
-      PostalCodes.regex_for_territory(territory).should == regex
+      expect(PostalCodes.regex_for_territory(territory)).to eq(regex)
     end
 
     it 'returns nil if the regex is missing' do
-      PostalCodes.regex_for_territory(:foo).should be_nil
+      expect(PostalCodes.regex_for_territory(:foo)).to be_nil
     end
 
     it 'accepts strings' do
-      PostalCodes.regex_for_territory(territory.to_s).should == regex
+      expect(PostalCodes.regex_for_territory(territory.to_s)).to eq(regex)
     end
 
     it 'accepts upper-case strings' do
-      PostalCodes.regex_for_territory(territory.to_s.upcase).should == regex
+      expect(PostalCodes.regex_for_territory(territory.to_s.upcase)).to eq(regex)
     end
   end
 
@@ -54,15 +54,15 @@ describe PostalCodes do
     before(:each) { mock(PostalCodes).resource { { territory => regex } } }
 
     it 'returns true if a given postal code satisfies the regexp' do
-      PostalCodes.valid?(territory, '12345-321').should be_true
+      expect(PostalCodes.valid?(territory, '12345-321')).to be_true
     end
 
     it "returns false if a given postal code doesn't satisfy the regexp" do
-      PostalCodes.valid?(territory, 'postal-code').should be_false
+      expect(PostalCodes.valid?(territory, 'postal-code')).to be_false
     end
 
     it 'returns false if the regexp is missing' do
-      PostalCodes.valid?(:foo, '12345-321').should be_false
+      expect(PostalCodes.valid?(:foo, '12345-321')).to be_false
     end
   end
 end

--- a/spec/shared/territories_spec.rb
+++ b/spec/shared/territories_spec.rb
@@ -10,109 +10,109 @@ include TwitterCldr::Shared
 describe Territories do
   describe "#translate_territory" do
     it "should translate country names from one locale to another" do
-      Territories.translate_territory("Russia", :en, :es).should match_normalized("Rusia")
-      Territories.translate_territory("Rusia", :es, :en).should match_normalized("Russia")
-      Territories.translate_territory("Spain", :en, :es).should match_normalized("España")
-      Territories.translate_territory("España", :es, :ru).should match_normalized("Испания")
+      expect(Territories.translate_territory("Russia", :en, :es)).to match_normalized("Rusia")
+      expect(Territories.translate_territory("Rusia", :es, :en)).to match_normalized("Russia")
+      expect(Territories.translate_territory("Spain", :en, :es)).to match_normalized("España")
+      expect(Territories.translate_territory("España", :es, :ru)).to match_normalized("Испания")
     end
 
     it "should use alternate/short names" do
-      Territories.translate_territory("Congo (DRC)", :en, :es).should match_normalized("Congo (República Democrática del Congo)")
-      Territories.translate_territory("Congo (Republic)", :en, :es).should match_normalized("Congo (República)")
-      Territories.translate_territory("East Timor", :en, :es).should match_normalized("Timor Oriental")
-      Territories.translate_territory("Falkland Islands (Islas Malvinas)", :en, :es).should match_normalized("Islas Malvinas (Islas Falkland)")
-      Territories.translate_territory("Hong Kong", :en, :es).should match_normalized("Hong Kong")
-      Territories.translate_territory("Ivory Coast", :en, :es).should match_normalized("Costa de Marfil")
-      Territories.translate_territory("Macau", :en, :es).should match_normalized("Macao")
-      Territories.translate_territory("Macedonia (FYROM)", :en, :es).should match_normalized("Macedonia (ERYM)")
+      expect(Territories.translate_territory("Congo (DRC)", :en, :es)).to match_normalized("Congo (República Democrática del Congo)")
+      expect(Territories.translate_territory("Congo (Republic)", :en, :es)).to match_normalized("Congo (República)")
+      expect(Territories.translate_territory("East Timor", :en, :es)).to match_normalized("Timor Oriental")
+      expect(Territories.translate_territory("Falkland Islands (Islas Malvinas)", :en, :es)).to match_normalized("Islas Malvinas (Islas Falkland)")
+      expect(Territories.translate_territory("Hong Kong", :en, :es)).to match_normalized("Hong Kong")
+      expect(Territories.translate_territory("Ivory Coast", :en, :es)).to match_normalized("Costa de Marfil")
+      expect(Territories.translate_territory("Macau", :en, :es)).to match_normalized("Macao")
+      expect(Territories.translate_territory("Macedonia (FYROM)", :en, :es)).to match_normalized("Macedonia (ERYM)")
     end
 
     it "should be capitalization agnostic" do
-      Territories.translate_territory("russia", :en, :es).should match_normalized("Rusia")
-      Territories.translate_territory("RUSSIA", :en, :es).should match_normalized("Rusia")
+      expect(Territories.translate_territory("russia", :en, :es)).to match_normalized("Rusia")
+      expect(Territories.translate_territory("RUSSIA", :en, :es)).to match_normalized("Rusia")
     end
 
     it "defaults the destination language to English (or whatever the global locale is)" do
-      Territories.translate_territory("Rusia", :es).should match_normalized("Russia")
-      Territories.translate_territory("Россия", :ru).should match_normalized("Russia")
+      expect(Territories.translate_territory("Rusia", :es)).to match_normalized("Russia")
+      expect(Territories.translate_territory("Россия", :ru)).to match_normalized("Russia")
     end
 
     it "defaults source and destination language to English if not given" do
-      Territories.translate_territory("Russia").should match_normalized("Russia")
+      expect(Territories.translate_territory("Russia")).to match_normalized("Russia")
       TwitterCldr.locale = :es
-      Territories.translate_territory("Russia").should match_normalized("Rusia")
+      expect(Territories.translate_territory("Russia")).to match_normalized("Rusia")
     end
 
     it "successfully translates locale codes that are and are not in the CLDR using the locale map" do
-      Territories.translate_territory("Russia", :en, :'zh-cn').should match_normalized("俄罗斯")
-      Territories.translate_territory("Russia", :en, :'zh').should match_normalized("俄罗斯")
+      expect(Territories.translate_territory("Russia", :en, :'zh-cn')).to match_normalized("俄罗斯")
+      expect(Territories.translate_territory("Russia", :en, :'zh')).to match_normalized("俄罗斯")
     end
 
     it "should return nil if no translation was found" do
-      Territories.translate_territory("Russia", :en, :blarg).should == nil
+      expect(Territories.translate_territory("Russia", :en, :blarg)).to eq(nil)
     end
   end
 
   describe "#from_territory_code_for_locale" do
     it "should return the territory in the correct locale for the given locale code (i.e. RU in English should be Russia)" do
-      Territories.from_territory_code_for_locale(:ES, :en).should match_normalized("Spain")
-      Territories.from_territory_code_for_locale(:GB, :es).should match_normalized("UK")
+      expect(Territories.from_territory_code_for_locale(:ES, :en)).to match_normalized("Spain")
+      expect(Territories.from_territory_code_for_locale(:GB, :es)).to match_normalized("UK")
     end
 
     it "should work with lower-case country codes as well" do
-      Territories.from_territory_code_for_locale(:es, :en).should match_normalized("Spain")
-      Territories.from_territory_code_for_locale(:gb, :es).should match_normalized("UK")
+      expect(Territories.from_territory_code_for_locale(:es, :en)).to match_normalized("Spain")
+      expect(Territories.from_territory_code_for_locale(:gb, :es)).to match_normalized("UK")
     end
 
     it "should work with Traditional Chinese" do
-      Territories.from_territory_code_for_locale(:US, :"zh-Hant").should match_normalized("美國")
+      expect(Territories.from_territory_code_for_locale(:US, :"zh-Hant")).to match_normalized("美國")
     end
   end
 
   describe "#from_territory_code" do
     it "should return the language in the default locale for the given locale code" do
-      Territories.from_territory_code(:ES).should match_normalized("Spain")
-      Territories.from_territory_code(:RU).should match_normalized("Russia")
+      expect(Territories.from_territory_code(:ES)).to match_normalized("Spain")
+      expect(Territories.from_territory_code(:RU)).to match_normalized("Russia")
       TwitterCldr.locale = :es
-      Territories.from_territory_code(:ES).should match_normalized("España")
+      expect(Territories.from_territory_code(:ES)).to match_normalized("España")
     end
   end
 
   describe "#all_for" do
     it "should return a hash of all languages for the given language code" do
       territories = Territories.all_for(:es)
-      territories.should be_a(Hash)
-      territories[:ru].should match_normalized("Rusia")
+      expect(territories).to be_a(Hash)
+      expect(territories[:ru]).to match_normalized("Rusia")
     end
 
     it "should return an empty hash for an invalid language" do
       territories = Territories.all_for(:blarg)
-      territories.should == {}
+      expect(territories).to eq({})
     end
   end
 
   describe "#all" do
     it "should use the default language to get the language hash" do
       territories = Territories.all
-      territories.should be_a(Hash)
-      territories[:ru].should match_normalized("Russia")
-      territories[:de].should match_normalized("Germany")
+      expect(territories).to be_a(Hash)
+      expect(territories[:ru]).to match_normalized("Russia")
+      expect(territories[:de]).to match_normalized("Germany")
 
       TwitterCldr.locale = :es
       territories = Territories.all
-      territories.should be_a(Hash)
-      territories[:ru].should match_normalized("Rusia")
-      territories[:de].should match_normalized("Alemania")
+      expect(territories).to be_a(Hash)
+      expect(territories[:ru]).to match_normalized("Rusia")
+      expect(territories[:de]).to match_normalized("Alemania")
     end
   end
 
   describe "the lack of knowledge about three-digit UN area codes" do
     it "should not be able to translate three-digit UN area codes" do
-      Territories.translate_territory("Southern Africa", :en, :es).should == nil
+      expect(Territories.translate_territory("Southern Africa", :en, :es)).to eq(nil)
     end
 
     it "should not be able to name three-digit UN area codes" do
-      Territories.from_territory_code_for_locale(:"18", :es).should == nil
+      expect(Territories.from_territory_code_for_locale(:"18", :es)).to eq(nil)
     end
   end
 

--- a/spec/shared/unicode_regex_spec.rb
+++ b/spec/shared/unicode_regex_spec.rb
@@ -25,40 +25,40 @@ describe UnicodeRegex do
 
     describe "#compile" do
       it "should return a UnicodeRegex, parsed and ready to go" do
-        regex.should be_a(UnicodeRegex)
+        expect(regex).to be_a(UnicodeRegex)
       end
     end
 
     describe "#to_regexp_str" do
       it "should return the string representation of this regex" do
-        regex.to_regexp_str.should == "(?:[\\141-\\143])"
+        expect(regex.to_regexp_str).to eq("(?:[\\141-\\143])")
       end
     end
 
     describe "#to_regexp" do
       it "should return a ruby Regexp" do
         if RUBY_VERSION <= "1.8.7"
-          regex.to_regexp.should be_a(Oniguruma::ORegexp)
+          expect(regex.to_regexp).to be_a(Oniguruma::ORegexp)
         else
-          regex.to_regexp.should be_a(Regexp)
+          expect(regex.to_regexp).to be_a(Regexp)
         end
       end
 
       it "should properly turn various basic regexes into strings" do
-        compile("^abc$").to_regexp_str.should == "^(?:\\141)(?:\\142)(?:\\143)$"
-        compile("a(b)c").to_regexp_str.should == "(?:\\141)((?:\\142))(?:\\143)"
-        compile("a(?:b)c").to_regexp_str.should == "(?:\\141)(?:(?:\\142))(?:\\143)"
-        compile("a{1,3}").to_regexp_str.should == "(?:\\141){1,3}"
-        compile("[abc]").to_regexp_str.should == "(?:[\\141-\\143])"
+        expect(compile("^abc$").to_regexp_str).to eq("^(?:\\141)(?:\\142)(?:\\143)$")
+        expect(compile("a(b)c").to_regexp_str).to eq("(?:\\141)((?:\\142))(?:\\143)")
+        expect(compile("a(?:b)c").to_regexp_str).to eq("(?:\\141)(?:(?:\\142))(?:\\143)")
+        expect(compile("a{1,3}").to_regexp_str).to eq("(?:\\141){1,3}")
+        expect(compile("[abc]").to_regexp_str).to eq("(?:[\\141-\\143])")
       end
 
       it "should properly turn various complex regexes into strings" do
-        compile("[a-z0-9]").to_regexp_str.should == "(?:[\\60-\\71]|[\\141-\\172])"
-        compile("[\\u0067-\\u0071]").to_regexp_str.should == "(?:[\\147-\\161])"
+        expect(compile("[a-z0-9]").to_regexp_str).to eq("(?:[\\60-\\71]|[\\141-\\172])")
+        expect(compile("[\\u0067-\\u0071]").to_regexp_str).to eq("(?:[\\147-\\161])")
       end
 
       it "should properly substitute variables" do
-        compile("$FOO$BAR", symbol_table).to_regexp_str.should == "(?:[\\147-\\153])(?:[\\160-\\163])"
+        expect(compile("$FOO$BAR", symbol_table).to_regexp_str).to eq("(?:[\\147-\\153])(?:[\\160-\\163])")
       end
     end
   end
@@ -67,10 +67,10 @@ describe UnicodeRegex do
     describe "#match" do
       it "should substitute variables from the symbol table" do
         regex = compile("$FOO $BAR", symbol_table)
-        regex.should exactly_match("h r")
-        regex.should exactly_match("j q")
-        regex.should_not exactly_match("h t")
-        regex.should_not exactly_match("c s")
+        expect(regex).to exactly_match("h r")
+        expect(regex).to exactly_match("j q")
+        expect(regex).not_to exactly_match("h t")
+        expect(regex).not_to exactly_match("c s")
       end
     end
   end
@@ -79,40 +79,40 @@ describe UnicodeRegex do
     describe "#match" do
       it "should match a regex with no char class" do
         regex = compile("^abc$")
-        regex.should exactly_match("abc")
-        regex.should_not exactly_match("cba")
+        expect(regex).to exactly_match("abc")
+        expect(regex).not_to exactly_match("cba")
       end
 
       it "should match a regex with a capturing group" do
         regex = compile("a(b)c")
         match = regex.match("abc")
-        match.should_not be_nil
-        match.captures[0].should == "b"
+        expect(match).not_to be_nil
+        expect(match.captures[0]).to eq("b")
       end
 
       it "should match a regex with a non-capturing group" do
         regex = compile("a(?:b)c")
         match = regex.match("abc")
-        match.should_not be_nil
-        match.captures.should == []
+        expect(match).not_to be_nil
+        expect(match.captures).to eq([])
       end
 
       it "should match a regex with a quantifier" do
         regex = compile("a{1,3}")
-        regex.should exactly_match("a")
-        regex.should exactly_match("aa")
-        regex.should exactly_match("aaa")
-        regex.should_not exactly_match("aaaa")
-        regex.should_not exactly_match("b")
+        expect(regex).to exactly_match("a")
+        expect(regex).to exactly_match("aa")
+        expect(regex).to exactly_match("aaa")
+        expect(regex).not_to exactly_match("aaaa")
+        expect(regex).not_to exactly_match("b")
       end
 
       it "should match a regex with a basic char class" do
         regex = compile("[abc]")
-        regex.should exactly_match("a")
-        regex.should exactly_match("b")
-        regex.should exactly_match("c")
-        regex.should_not exactly_match("ab")
-        regex.should_not exactly_match("d")
+        expect(regex).to exactly_match("a")
+        expect(regex).to exactly_match("b")
+        expect(regex).to exactly_match("c")
+        expect(regex).not_to exactly_match("ab")
+        expect(regex).not_to exactly_match("d")
       end
     end
   end
@@ -121,82 +121,82 @@ describe UnicodeRegex do
     describe "#match" do
       it "should match a regex with a char class containing a range" do
         regex = compile("[a-z0-9]")
-        regex.should exactly_match("a")
-        regex.should exactly_match("m")
-        regex.should exactly_match("z")
-        regex.should exactly_match("0")
-        regex.should exactly_match("3")
-        regex.should exactly_match("9")
-        regex.should_not exactly_match("a0")
-        regex.should_not exactly_match("m4")
+        expect(regex).to exactly_match("a")
+        expect(regex).to exactly_match("m")
+        expect(regex).to exactly_match("z")
+        expect(regex).to exactly_match("0")
+        expect(regex).to exactly_match("3")
+        expect(regex).to exactly_match("9")
+        expect(regex).not_to exactly_match("a0")
+        expect(regex).not_to exactly_match("m4")
       end
 
       it "should match a regex with a char class containing a unicode range" do
         regex = compile("[\\u0067-\\u0071]")  # g-q
-        regex.should exactly_match("g")
-        regex.should exactly_match("q")
-        regex.should exactly_match("h")
-        regex.should_not exactly_match("z")
+        expect(regex).to exactly_match("g")
+        expect(regex).to exactly_match("q")
+        expect(regex).to exactly_match("h")
+        expect(regex).not_to exactly_match("z")
       end
 
       it "should match a regex containing a character set" do
         regex = compile("[\\p{Zs}]")
-        regex.should exactly_match([160].pack("U*"))  # non-breaking space
-        regex.should exactly_match([5760].pack("U*"))  # ogham space mark
-        regex.should_not exactly_match("a")
+        expect(regex).to exactly_match([160].pack("U*"))  # non-breaking space
+        expect(regex).to exactly_match([5760].pack("U*"))  # ogham space mark
+        expect(regex).not_to exactly_match("a")
       end
 
       it "should match a regex containing a negated character set" do
         regex = compile("[\\P{Zs}]")
-        regex.should exactly_match("a")
-        regex.should_not exactly_match([160].pack("U*"))
-        regex.should_not exactly_match([5760].pack("U*"))
+        expect(regex).to exactly_match("a")
+        expect(regex).not_to exactly_match([160].pack("U*"))
+        expect(regex).not_to exactly_match([5760].pack("U*"))
       end
 
       it "should match a regex containing a character set (alternate syntax)" do
         regex = compile("[[:Zs:]]")
-        regex.should exactly_match([160].pack("U*"))  # non-breaking space
-        regex.should exactly_match([5760].pack("U*"))  # ogham space mark
-        regex.should_not exactly_match("a")
+        expect(regex).to exactly_match([160].pack("U*"))  # non-breaking space
+        expect(regex).to exactly_match([5760].pack("U*"))  # ogham space mark
+        expect(regex).not_to exactly_match("a")
       end
 
       it "should match a regex containing a negated character set (alternate syntax)" do
         regex = compile("[[:^Zs:]]")
-        regex.should exactly_match("a")
-        regex.should_not exactly_match([160].pack("U*"))
-        regex.should_not exactly_match([5760].pack("U*"))
+        expect(regex).to exactly_match("a")
+        expect(regex).not_to exactly_match([160].pack("U*"))
+        expect(regex).not_to exactly_match([5760].pack("U*"))
       end
 
       it "should match a regex with a character set and some quantifiers" do
         regex = compile("[\\u0067-\\u0071]+")
-        regex.should exactly_match("gg")
-        regex.should exactly_match("gh")
-        regex.should exactly_match("qjk")
-        regex.should_not exactly_match("")
+        expect(regex).to exactly_match("gg")
+        expect(regex).to exactly_match("gh")
+        expect(regex).to exactly_match("qjk")
+        expect(regex).not_to exactly_match("")
       end
 
       it "should match a regex that uses special switches inside the char class" do
         regex = compile("[\\w]+")
-        regex.should exactly_match("a")
-        regex.should exactly_match("abc")
-        regex.should exactly_match("a0b_1c2")
-        regex.should_not exactly_match("$@#")
+        expect(regex).to exactly_match("a")
+        expect(regex).to exactly_match("abc")
+        expect(regex).to exactly_match("a0b_1c2")
+        expect(regex).not_to exactly_match("$@#")
       end
 
       it "should match a regex that uses negated special switches inside the char class" do
         regex = compile("[\\W]+")
-        regex.should_not exactly_match("a")
-        regex.should_not exactly_match("abc")
-        regex.should_not exactly_match("a0b_1c2")
-        regex.should exactly_match("$@#")
+        expect(regex).not_to exactly_match("a")
+        expect(regex).not_to exactly_match("abc")
+        expect(regex).not_to exactly_match("a0b_1c2")
+        expect(regex).to exactly_match("$@#")
       end
 
       it "should match a regex with a complicated expression inside the char class" do
         # not [separators U space-tilde] diff [letters diff numbers]  (diff is commutative)
         regex = compile("[^[\\p{Z}\\u0020-\\u007f]-[\\p{L}]-[\\p{N}]]")
-        regex.should exactly_match(" ")
-        regex.should exactly_match(",")
-        regex.should_not exactly_match("a")
+        expect(regex).to exactly_match(" ")
+        expect(regex).to exactly_match(",")
+        expect(regex).not_to exactly_match("a")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,10 +80,10 @@ RSpec::Matchers.define :exactly_match do |expected|
 end
 
 def check_token_list(got, expected)
-  got.size.should == expected.size
+  expect(got.size).to eq(expected.size)
   expected.each_with_index do |exp_hash, index|
     exp_hash.each_pair do |exp_key, exp_val|
-      got[index].send(exp_key).should == exp_val
+      expect(got[index].send(exp_key)).to eq(exp_val)
     end
   end
 end

--- a/spec/tokenizers/calendars/date_tokenizer_spec.rb
+++ b/spec/tokenizers/calendars/date_tokenizer_spec.rb
@@ -41,7 +41,7 @@ describe DateTokenizer do
 
     it "should tokenize composites correctly" do
       # Ensure that buddhist calendar data is present in th locale.
-      TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist].should_not(
+      expect(TwitterCldr.get_locale_resource(:th, :calendars)[:th][:calendars][:buddhist]).not_to(
         be_nil, 'buddhist calendar is missing for :th locale (check resources/locales/th/calendars.yml)'
       )
 

--- a/spec/tokenizers/calendars/timespan_tokenizer_spec.rb
+++ b/spec/tokenizers/calendars/timespan_tokenizer_spec.rb
@@ -14,18 +14,18 @@ describe TimespanTokenizer do
       tokenizer = TimespanTokenizer.new(nil)
       tokenizer.tokenize("Hace {0} minutos").tap do |tokens|
         tokens[0].tap do |token|
-          token.value.should == "Hace "
-          token.type.should == :plaintext
+          expect(token.value).to eq("Hace ")
+          expect(token.type).to eq(:plaintext)
         end
 
         tokens[1].tap do |token|
-          token.value.should == "{0}"
-          token.type.should == :pattern
+          expect(token.value).to eq("{0}")
+          expect(token.type).to eq(:pattern)
         end
 
         tokens[2].tap do |token|
-          token.value.should == " minutos"
-          token.type.should == :plaintext
+          expect(token.value).to eq(" minutos")
+          expect(token.type).to eq(:plaintext)
         end
       end
     end

--- a/spec/tokenizers/composite_token_spec.rb
+++ b/spec/tokenizers/composite_token_spec.rb
@@ -14,8 +14,8 @@ describe CompositeToken do
   		token_1 = Token.new(:type => "my_type_1", :value => "my_value_1")
 
   		composite_token = CompositeToken.new([token_0, token_1])
-  		composite_token.tokens.map { |t| t.type }.should == ["my_type_0", "my_type_1"]
-  		composite_token.tokens.map { |t| t.value }.should == ["my_value_0", "my_value_1"]
+  		expect(composite_token.tokens.map { |t| t.type }).to eq(["my_type_0", "my_type_1"])
+  		expect(composite_token.tokens.map { |t| t.value }).to eq(["my_value_0", "my_value_1"])
   	end
 
     it "should return content" do
@@ -23,7 +23,7 @@ describe CompositeToken do
   		token_1 = Token.new(:type => "my_type_1", :value => "my_value_1")
 
   		composite_token = CompositeToken.new([token_0, token_1])
-  		composite_token.to_s.should == "my_value_0my_value_1"
+  		expect(composite_token.to_s).to eq("my_value_0my_value_1")
   	end
   end
 end

--- a/spec/tokenizers/token_spec.rb
+++ b/spec/tokenizers/token_spec.rb
@@ -11,14 +11,14 @@ describe Token do
   describe "#initialize" do
     it "should set instance variables passed in the options hash" do
       token = Token.new(:type => "my_type", :value => "my_value")
-      token.type.should == "my_type"
-      token.value.should == "my_value"
+      expect(token.type).to eq("my_type")
+      expect(token.value).to eq("my_value")
     end
   end
 
   describe "#to_s" do
     it "should return the token's value" do
-      Token.new(:value => "my_value").to_s.should == "my_value"
+      expect(Token.new(:value => "my_value").to_s).to eq("my_value")
     end
   end
 end

--- a/spec/twitter_cldr_spec.rb
+++ b/spec/twitter_cldr_spec.rb
@@ -8,57 +8,57 @@ require 'spec_helper'
 describe TwitterCldr do
   describe "#supported_locale?" do
     it "should return true if the locale is supported" do
-      TwitterCldr.supported_locale?(:es).should be_true
-      TwitterCldr.supported_locale?("es").should be_true
+      expect(TwitterCldr.supported_locale?(:es)).to be_true
+      expect(TwitterCldr.supported_locale?("es")).to be_true
     end
 
     it "should return false if the locale isn't supported" do
-      TwitterCldr.supported_locale?(:bogus).should be_false
-      TwitterCldr.supported_locale?("bogus").should be_false
+      expect(TwitterCldr.supported_locale?(:bogus)).to be_false
+      expect(TwitterCldr.supported_locale?("bogus")).to be_false
     end
 
     it "should return true if the given locale code is twitter-specific" do
-      TwitterCldr.supported_locale?(:'zh-cn').should be_true
-      TwitterCldr.supported_locale?(:'zh-tw').should be_true
-      TwitterCldr.supported_locale?(:msa).should be_true
+      expect(TwitterCldr.supported_locale?(:'zh-cn')).to be_true
+      expect(TwitterCldr.supported_locale?(:'zh-tw')).to be_true
+      expect(TwitterCldr.supported_locale?(:msa)).to be_true
     end
   end
 
   describe "#supported_locales" do
     it "should return an array of currently supported locale codes" do
       locales = TwitterCldr.supported_locales
-      locales.should include(:es)
-      locales.should include(:zh)
-      locales.should include(:nb)
-      locales.should include(:ja)
+      expect(locales).to include(:es)
+      expect(locales).to include(:zh)
+      expect(locales).to include(:nb)
+      expect(locales).to include(:ja)
     end
 
     it 'should not include :shared or :unicode_data' do
-      (TwitterCldr.supported_locales & [:shared, :unicode_data]).should be_empty
+      expect(TwitterCldr.supported_locales & [:shared, :unicode_data]).to be_empty
     end
   end
 
   describe "#convert_locale" do
     it "should convert a twitter locale to a CLDR locale" do
-      TwitterCldr.convert_locale(:msa).should == :ms
-      TwitterCldr.convert_locale(:'zh-cn').should == :zh
-      TwitterCldr.convert_locale(:'zh-tw').should == :'zh-Hant'
+      expect(TwitterCldr.convert_locale(:msa)).to eq(:ms)
+      expect(TwitterCldr.convert_locale(:'zh-cn')).to eq(:zh)
+      expect(TwitterCldr.convert_locale(:'zh-tw')).to eq(:'zh-Hant')
     end
 
     it "should leave unknown locales alone" do
-      TwitterCldr.convert_locale(:blarg).should == :blarg
+      expect(TwitterCldr.convert_locale(:blarg)).to eq(:blarg)
     end
   end
 
   describe "#twitter_locale" do
     it "should convert a CLDR locale to a twitter locale" do
-      TwitterCldr.twitter_locale(:ms).should == :msa
-      TwitterCldr.twitter_locale(:zh).should == :'zh-cn'
-      TwitterCldr.twitter_locale(:'zh-Hant').should == :'zh-tw'
+      expect(TwitterCldr.twitter_locale(:ms)).to eq(:msa)
+      expect(TwitterCldr.twitter_locale(:zh)).to eq(:'zh-cn')
+      expect(TwitterCldr.twitter_locale(:'zh-Hant')).to eq(:'zh-tw')
     end
 
     it "should leave unknown locales alone" do
-      TwitterCldr.twitter_locale(:blarg).should == :blarg
+      expect(TwitterCldr.twitter_locale(:blarg)).to eq(:blarg)
     end
   end
 
@@ -66,22 +66,22 @@ describe TwitterCldr do
     context "with explicit locale" do
       it "should return the same locale the user sets (if it's supported)" do
         TwitterCldr.locale = :es
-        TwitterCldr.locale.should == :es
+        expect(TwitterCldr.locale).to eq(:es)
       end
 
       it "should convert strings to symbols" do
         TwitterCldr.locale = "es"
-        TwitterCldr.locale.should == :es
+        expect(TwitterCldr.locale).to eq(:es)
       end
 
       it "should fall back if the user sets an unsupported locale" do
         FastGettext.locale = :ko
         TwitterCldr.locale = "blarg"
-        TwitterCldr.locale.should == :ko
+        expect(TwitterCldr.locale).to eq(:ko)
 
         FastGettext.locale = nil
         I18n.locale = :hu
-        TwitterCldr.locale.should == :hu
+        expect(TwitterCldr.locale).to eq(:hu)
       end
     end
 
@@ -93,13 +93,13 @@ describe TwitterCldr do
       it "should return FastGettext locale before I18n locale and fall back gracefully" do
         FastGettext.locale = :pt
         I18n.locale = :ar
-        TwitterCldr.locale.should == :pt
+        expect(TwitterCldr.locale).to eq(:pt)
 
         FastGettext.locale = nil
-        TwitterCldr.locale.should == :ar
+        expect(TwitterCldr.locale).to eq(:ar)
 
         I18n.locale = nil
-        TwitterCldr.locale.should == :en
+        expect(TwitterCldr.locale).to eq(:en)
       end
 
       context "with only FastGettext locale" do
@@ -109,12 +109,12 @@ describe TwitterCldr do
 
         it "should return the FastGettext locale if it's supported" do
           FastGettext.locale = "vi"
-          TwitterCldr.locale.should == :vi
+          expect(TwitterCldr.locale).to eq(:vi)
         end
 
         it "should return the default locale if the FastGettext locale is unsupported" do
           FastGettext.locale = "bogus"
-          TwitterCldr.locale.should == TwitterCldr::DEFAULT_LOCALE
+          expect(TwitterCldr.locale).to eq(TwitterCldr::DEFAULT_LOCALE)
         end
       end
 
@@ -125,12 +125,12 @@ describe TwitterCldr do
 
         it "should return the I18n locale if it's supported" do
           I18n.locale = "ru"
-          TwitterCldr.locale.should == :ru
+          expect(TwitterCldr.locale).to eq(:ru)
         end
 
         it "should return the default locale if the I18n locale is unsupported" do
           I18n.locale = "bogus"
-          TwitterCldr.locale.should == TwitterCldr::DEFAULT_LOCALE
+          expect(TwitterCldr.locale).to eq(TwitterCldr::DEFAULT_LOCALE)
         end
       end
 
@@ -141,33 +141,33 @@ describe TwitterCldr do
         end
 
         it "should fall back to the custom locale" do
-          TwitterCldr.locale.should == :en
+          expect(TwitterCldr.locale).to eq(:en)
           @allow = true
-          TwitterCldr.locale.should == :uk
+          expect(TwitterCldr.locale).to eq(:uk)
         end
 
         it "should fall back to the next fallback option if the custom one returns nil" do
           FastGettext.locale = :lv
-          TwitterCldr.locale.should == :lv
+          expect(TwitterCldr.locale).to eq(:lv)
           @allow = true
-          TwitterCldr.locale.should == :uk
+          expect(TwitterCldr.locale).to eq(:uk)
         end
 
         it "should not return the fallback locale if it's unsupported" do
           TwitterCldr.reset_locale_fallbacks
           TwitterCldr.register_locale_fallback(lambda { :zzz })
-          TwitterCldr.locale.should == :en
+          expect(TwitterCldr.locale).to eq(:en)
         end
       end
 
       it "should fall back if the user sets an unsupported locale" do
         FastGettext.locale = :ko
         TwitterCldr.locale = "blarg"
-        TwitterCldr.locale.should == :ko
+        expect(TwitterCldr.locale).to eq(:ko)
 
         FastGettext.locale = nil
         I18n.locale = :hu
-        TwitterCldr.locale.should == :hu
+        expect(TwitterCldr.locale).to eq(:hu)
       end
     end
 
@@ -179,13 +179,13 @@ describe TwitterCldr do
       it "should return FastGettext locale before I18n locale and fall back gracefully" do
         FastGettext.locale = :pt
         I18n.locale = :ar
-        TwitterCldr.locale.should == :pt
+        expect(TwitterCldr.locale).to eq(:pt)
 
         FastGettext.locale = nil
-        TwitterCldr.locale.should == :ar
+        expect(TwitterCldr.locale).to eq(:ar)
 
         I18n.locale = nil
-        TwitterCldr.locale.should == :en
+        expect(TwitterCldr.locale).to eq(:en)
       end
 
       context "with only FastGettext locale" do
@@ -195,12 +195,12 @@ describe TwitterCldr do
 
         it "should return the FastGettext locale if it's supported" do
           FastGettext.locale = "vi"
-          TwitterCldr.locale.should == :vi
+          expect(TwitterCldr.locale).to eq(:vi)
         end
 
         it "should return the default locale if the FastGettext locale is unsupported" do
           FastGettext.locale = "bogus"
-          TwitterCldr.locale.should == TwitterCldr::DEFAULT_LOCALE
+          expect(TwitterCldr.locale).to eq(TwitterCldr::DEFAULT_LOCALE)
         end
       end
 
@@ -211,12 +211,12 @@ describe TwitterCldr do
 
         it "should return the I18n locale if it's supported" do
           I18n.locale = "ru"
-          TwitterCldr.locale.should == :ru
+          expect(TwitterCldr.locale).to eq(:ru)
         end
 
         it "should return the default locale if the I18n locale is unsupported" do
           I18n.locale = "bogus"
-          TwitterCldr.locale.should == TwitterCldr::DEFAULT_LOCALE
+          expect(TwitterCldr.locale).to eq(TwitterCldr::DEFAULT_LOCALE)
         end
       end
 
@@ -227,22 +227,22 @@ describe TwitterCldr do
         end
 
         it "should fall back to the custom locale" do
-          TwitterCldr.locale.should == :en
+          expect(TwitterCldr.locale).to eq(:en)
           @allow = true
-          TwitterCldr.locale.should == :uk
+          expect(TwitterCldr.locale).to eq(:uk)
         end
 
         it "should fall back to the next fallback option if the custom one returns nil" do
           FastGettext.locale = :lv
-          TwitterCldr.locale.should == :lv
+          expect(TwitterCldr.locale).to eq(:lv)
           @allow = true
-          TwitterCldr.locale.should == :uk
+          expect(TwitterCldr.locale).to eq(:uk)
         end
 
         it "should not return the fallback locale if it's unsupported" do
           TwitterCldr.reset_locale_fallbacks
           TwitterCldr.register_locale_fallback(lambda { :zzz })
-          TwitterCldr.locale.should == :en
+          expect(TwitterCldr.locale).to eq(:en)
         end
       end
     end
@@ -250,54 +250,54 @@ describe TwitterCldr do
 
   describe "#with_locale" do
     it "should only change the locale in the context of the block" do
-      TwitterCldr::Shared::Languages.from_code(:es).should == "Spanish"
-      TwitterCldr.with_locale(:es) { TwitterCldr::Shared::Languages.from_code(:es) }.should match_normalized("español")
-      TwitterCldr::Shared::Languages.from_code(:es).should == "Spanish"
+      expect(TwitterCldr::Shared::Languages.from_code(:es)).to eq("Spanish")
+      expect(TwitterCldr.with_locale(:es) { TwitterCldr::Shared::Languages.from_code(:es) }).to match_normalized("español")
+      expect(TwitterCldr::Shared::Languages.from_code(:es)).to eq("Spanish")
     end
 
     it "switches the locale back to the original if the block raises an error" do
-      TwitterCldr.locale.should == :en
+      expect(TwitterCldr.locale).to eq(:en)
       locale_inside_block = nil
 
-      lambda do
+      expect do
         TwitterCldr.with_locale(:es) do
           locale_inside_block = TwitterCldr.locale
           raise "Error!"
         end
-      end.should raise_error
+      end.to raise_error
 
-      locale_inside_block.should == :es
-      TwitterCldr.locale.should == :en
+      expect(locale_inside_block).to eq(:es)
+      expect(TwitterCldr.locale).to eq(:en)
     end
   end
 
   describe "#with_locale" do
     it "should only change the locale in the context of the block" do
-      TwitterCldr::Shared::Languages.from_code(:es).should == "Spanish"
-      TwitterCldr.with_locale(:es) { TwitterCldr::Shared::Languages.from_code(:es) }.should match_normalized("español")
-      TwitterCldr::Shared::Languages.from_code(:es).should == "Spanish"
+      expect(TwitterCldr::Shared::Languages.from_code(:es)).to eq("Spanish")
+      expect(TwitterCldr.with_locale(:es) { TwitterCldr::Shared::Languages.from_code(:es) }).to match_normalized("español")
+      expect(TwitterCldr::Shared::Languages.from_code(:es)).to eq("Spanish")
     end
 
     it "doesn't mess up if the given locale isn't supported" do
       TwitterCldr.locale = :pt
-      TwitterCldr.locale.should == :pt
-      lambda { TwitterCldr.with_locale(:xx) {} }.should raise_error
-      TwitterCldr.locale.should == :pt
+      expect(TwitterCldr.locale).to eq(:pt)
+      expect { TwitterCldr.with_locale(:xx) {} }.to raise_error
+      expect(TwitterCldr.locale).to eq(:pt)
     end
 
     it "switches the locale back to the original if the block raises an error" do
-      TwitterCldr.locale.should == :en
+      expect(TwitterCldr.locale).to eq(:en)
       locale_inside_block = nil
 
-      lambda do
+      expect do
         TwitterCldr.with_locale(:es) do
           locale_inside_block = TwitterCldr.locale
           raise "Error!"
         end
-      end.should raise_error
+      end.to raise_error
 
-      locale_inside_block.should == :es
-      TwitterCldr.locale.should == :en
+      expect(locale_inside_block).to eq(:es)
+      expect(TwitterCldr.locale).to eq(:en)
     end
   end
 
@@ -306,7 +306,7 @@ describe TwitterCldr do
       resources = TwitterCldr::Resources::Loader.new
       TwitterCldr.instance_variable_set(:@resources, resources)
 
-      TwitterCldr.resources.should == resources
+      expect(TwitterCldr.resources).to eq(resources)
     end
   end
 
@@ -317,7 +317,7 @@ describe TwitterCldr do
       stub(resources).get_resource(:shared, :currencies) { 'result' }
       stub(TwitterCldr).resources { resources }
 
-      TwitterCldr.get_resource(:shared, :currencies).should == 'result'
+      expect(TwitterCldr.get_resource(:shared, :currencies)).to eq('result')
     end
   end
 
@@ -326,7 +326,7 @@ describe TwitterCldr do
       stub(resources).get_locale_resource(:de, :numbers) { 'result' }
       stub(TwitterCldr).resources { resources }
 
-      TwitterCldr.get_locale_resource(:de, :numbers).should == 'result'
+      expect(TwitterCldr.get_locale_resource(:de, :numbers)).to eq('result')
     end
   end
 end

--- a/spec/utils/code_points_spec.rb
+++ b/spec/utils/code_points_spec.rb
@@ -9,53 +9,53 @@ describe TwitterCldr::Utils::CodePoints do
 
   describe '#to_char' do
     it 'converts unicode code points to the actual character' do
-      TwitterCldr::Utils::CodePoints.to_char(0x221E).should == '∞'
+      expect(TwitterCldr::Utils::CodePoints.to_char(0x221E)).to eq('∞')
     end
   end
 
   describe '#from_char' do
     it 'converts a character to a unicode code point' do
-      TwitterCldr::Utils::CodePoints.from_char('∞').should == 0x221E
+      expect(TwitterCldr::Utils::CodePoints.from_char('∞')).to eq(0x221E)
     end
   end
 
   describe '#to_chars' do
     it 'should handle an empty array' do
-      TwitterCldr::Utils::CodePoints.to_chars([]).should == []
+      expect(TwitterCldr::Utils::CodePoints.to_chars([])).to eq([])
     end
 
     it 'converts an array of unicode code points to an array of chars' do
-      TwitterCldr::Utils::CodePoints.to_chars([0x65, 0x73, 0x70]).should == %w[e s p]
+      expect(TwitterCldr::Utils::CodePoints.to_chars([0x65, 0x73, 0x70])).to eq(%w[e s p])
     end
   end
 
   describe '#from_chars' do
     it 'should handle an empty array' do
-      TwitterCldr::Utils::CodePoints.from_chars([]).should == []
+      expect(TwitterCldr::Utils::CodePoints.from_chars([])).to eq([])
     end
 
     it 'converts an array of chars to an array of unicode code points' do
-      TwitterCldr::Utils::CodePoints.from_chars(%w[e s p]).should == [0x65, 0x73, 0x70]
+      expect(TwitterCldr::Utils::CodePoints.from_chars(%w[e s p])).to eq([0x65, 0x73, 0x70])
     end
   end
 
   describe '#to_string' do
     it 'should handle an empty array' do
-      TwitterCldr::Utils::CodePoints.to_string([]).should == ''
+      expect(TwitterCldr::Utils::CodePoints.to_string([])).to eq('')
     end
 
     it 'converts an array of unicode code points to a string' do
-      TwitterCldr::Utils::CodePoints.to_string([0x65, 0x73, 0x70, 0x61, 0xF1, 0x6F, 0x6C]).should == 'español'
+      expect(TwitterCldr::Utils::CodePoints.to_string([0x65, 0x73, 0x70, 0x61, 0xF1, 0x6F, 0x6C])).to eq('español')
     end
   end
 
   describe '#from_string' do
     it 'should handle an empty string' do
-      TwitterCldr::Utils::CodePoints.from_string('').should == []
+      expect(TwitterCldr::Utils::CodePoints.from_string('')).to eq([])
     end
 
     it 'converts a string into an array of unicode code points' do
-      TwitterCldr::Utils::CodePoints.from_string('español').should == [0x65, 0x73, 0x70, 0x61, 0xF1, 0x6F, 0x6C]
+      expect(TwitterCldr::Utils::CodePoints.from_string('español')).to eq([0x65, 0x73, 0x70, 0x61, 0xF1, 0x6F, 0x6C])
     end
   end
 

--- a/spec/utils/interpolation_spec.rb
+++ b/spec/utils/interpolation_spec.rb
@@ -16,106 +16,106 @@ describe TwitterCldr::Utils do
 
     context 'when argument is a Hash' do
       it 'does nothing if no placeholder give' do
-        TwitterCldr::Utils.interpolate('foo', :foo => 'bar').should == 'foo'
+        expect(TwitterCldr::Utils.interpolate('foo', :foo => 'bar')).to eq('foo')
       end
 
       it 'interpolates named placeholders' do
-        TwitterCldr::Utils.interpolate('%{digit} %{sign} %{digit}', :digit => 2, :sign => '+').should == '2 + 2'
+        expect(TwitterCldr::Utils.interpolate('%{digit} %{sign} %{digit}', :digit => 2, :sign => '+')).to eq('2 + 2')
       end
 
       it 'interpolates named placeholders with formatting' do
-        TwitterCldr::Utils.interpolate(
+        expect(TwitterCldr::Utils.interpolate(
             '%<as_integer>d %<as_float>.2f', :as_integer => 3.14, :as_float => 15
-        ).should == '3 15.00'
+        )).to eq('3 15.00')
       end
 
       it 'interpolates mixed placeholders' do
-        TwitterCldr::Utils.interpolate(
+        expect(TwitterCldr::Utils.interpolate(
             '%{regular} is approx. %<pi>.4f', :regular => 'pi', :pi => 3.141592
-        ).should == 'pi is approx. 3.1416'
+        )).to eq('pi is approx. 3.1416')
       end
 
       it 'does not recurse' do
-        TwitterCldr::Utils.interpolate(
+        expect(TwitterCldr::Utils.interpolate(
             '%{top_level}', :top_level => '%<second_level>', :second_level => 'unexpected'
-        ).should == '%<second_level>'
+        )).to eq('%<second_level>')
       end
 
       it 'treats % before placeholder as escape character' do
-        TwitterCldr::Utils.interpolate(
+        expect(TwitterCldr::Utils.interpolate(
             '%%{foo} = %{foo}, %%<bar>d = %<bar>d', :foo => 1, :bar => 2.3
-        ).should == '%{foo} = 1, %<bar>d = 2'
+        )).to eq('%{foo} = 1, %<bar>d = 2')
       end
 
       it 'interpolates formatted placeholders as Ruby 1.9' do
-        TwitterCldr::Utils.interpolate('%<msg>s',    :msg => 'foo').should == 'foo'
-        TwitterCldr::Utils.interpolate('%<num>d',    :num => 1    ).should == '1'
-        TwitterCldr::Utils.interpolate('%<num>f',    :num => 1.0  ).should == '1.000000'
-        TwitterCldr::Utils.interpolate('%<num>3.0f', :num => 1.0  ).should == '  1'
-        TwitterCldr::Utils.interpolate('%<num>2.2f', :num => 100.0).should == '100.00'
-        TwitterCldr::Utils.interpolate('%<num>#b',   :num => 1    ).should == '0b1'
-        TwitterCldr::Utils.interpolate('%<num>#x',   :num => 100.0).should == '0x64'
+        expect(TwitterCldr::Utils.interpolate('%<msg>s',    :msg => 'foo')).to eq('foo')
+        expect(TwitterCldr::Utils.interpolate('%<num>d',    :num => 1    )).to eq('1')
+        expect(TwitterCldr::Utils.interpolate('%<num>f',    :num => 1.0  )).to eq('1.000000')
+        expect(TwitterCldr::Utils.interpolate('%<num>3.0f', :num => 1.0  )).to eq('  1')
+        expect(TwitterCldr::Utils.interpolate('%<num>2.2f', :num => 100.0)).to eq('100.00')
+        expect(TwitterCldr::Utils.interpolate('%<num>#b',   :num => 1    )).to eq('0b1')
+        expect(TwitterCldr::Utils.interpolate('%<num>#x',   :num => 100.0)).to eq('0x64')
       end
 
       it 'ignores extra values' do
-        TwitterCldr::Utils.interpolate('%{msg}', :msg => 'hello', :extra => 'extra').should == 'hello'
+        expect(TwitterCldr::Utils.interpolate('%{msg}', :msg => 'hello', :extra => 'extra')).to eq('hello')
       end
 
       it 'raises ArgumentError if formatted placeholder is malformed' do
-        lambda { TwitterCldr::Utils.interpolate('%<num>,d', :num => 100) }.should raise_error(ArgumentError)
-        lambda { TwitterCldr::Utils.interpolate('%<num>/d', :num => 100) }.should raise_error(ArgumentError)
+        expect { TwitterCldr::Utils.interpolate('%<num>,d', :num => 100) }.to raise_error(ArgumentError)
+        expect { TwitterCldr::Utils.interpolate('%<num>/d', :num => 100) }.to raise_error(ArgumentError)
       end
 
       it 'raises KeyError when the value is missing' do
-        lambda { TwitterCldr::Utils.interpolate('%{msg}', {}) }.should raise_error(KeyError)
+        expect { TwitterCldr::Utils.interpolate('%{msg}', {}) }.to raise_error(KeyError)
       end
     end
 
     context 'when argument is an Array' do
       it 'does nothing if no placeholder give' do
-        TwitterCldr::Utils.interpolate('foo', [111]).should == 'foo'
+        expect(TwitterCldr::Utils.interpolate('foo', [111])).to eq('foo')
       end
 
       it 'interpolates all placeholders' do
-        TwitterCldr::Utils.interpolate('%d %s', [12, 'monkeys']).should == '12 monkeys'
+        expect(TwitterCldr::Utils.interpolate('%d %s', [12, 'monkeys'])).to eq('12 monkeys')
       end
 
       it 'interpolates all placeholders with formatting' do
-        TwitterCldr::Utils.interpolate('%d %.3f %#b', [3.1415, 92, 6]).should == '3 92.000 0b110'
+        expect(TwitterCldr::Utils.interpolate('%d %.3f %#b', [3.1415, 92, 6])).to eq('3 92.000 0b110')
       end
 
       it 'formats positional arguments' do
-        TwitterCldr::Utils.interpolate('%1$*2$s %2$d %1$s', ['hello', 8]).should == '   hello 8 hello'
+        expect(TwitterCldr::Utils.interpolate('%1$*2$s %2$d %1$s', ['hello', 8])).to eq('   hello 8 hello')
       end
 
       it 'treats % as escape character' do
-        TwitterCldr::Utils.interpolate('%s: %+.2f±%.2f%%', ['total', 3.14159, 2.6535]).should == 'total: +3.14±2.65%'
+        expect(TwitterCldr::Utils.interpolate('%s: %+.2f±%.2f%%', ['total', 3.14159, 2.6535])).to eq('total: +3.14±2.65%')
       end
 
       it 'ignores extra values' do
-        TwitterCldr::Utils.interpolate('%d', [2, 1]).should == '2'
+        expect(TwitterCldr::Utils.interpolate('%d', [2, 1])).to eq('2')
       end
 
       it 'raises ArgumentError when given not enough values' do
-        lambda { TwitterCldr::Utils.interpolate('%d %d', [1]) }.should raise_error(ArgumentError)
+        expect { TwitterCldr::Utils.interpolate('%d %d', [1]) }.to raise_error(ArgumentError)
       end
 
       it 'raises ArgumentError if the string contains named placeholders' do
-        lambda { TwitterCldr::Utils.interpolate('%{name} %d', [1, 2]) }.should raise_error(ArgumentError)
+        expect { TwitterCldr::Utils.interpolate('%{name} %d', [1, 2]) }.to raise_error(ArgumentError)
       end
     end
 
     context 'when argument is a single value' do
       it 'formats a string' do
-        TwitterCldr::Utils.interpolate('a string: %s', 'string').should == 'a string: string'
+        expect(TwitterCldr::Utils.interpolate('a string: %s', 'string')).to eq('a string: string')
       end
 
       it 'formats a number' do
-        TwitterCldr::Utils.interpolate('a number: %4.1f', 3.1415).should == 'a number:  3.1'
+        expect(TwitterCldr::Utils.interpolate('a number: %4.1f', 3.1415)).to eq('a number:  3.1')
       end
 
       it 'raises ArgumentError if the string contains named placeholders' do
-        lambda { TwitterCldr::Utils.interpolate('%{name}', 'must be hash') }.should raise_error(ArgumentError)
+        expect { TwitterCldr::Utils.interpolate('%{name}', 'must be hash') }.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/utils/range_set_spec.rb
+++ b/spec/utils/range_set_spec.rb
@@ -10,48 +10,48 @@ include TwitterCldr::Utils
 describe RangeSet do
   describe "rangify" do
     it "should identify runs in an array of integers and return an array of ranges" do
-      RangeSet.rangify([1, 2, 3, 6, 7, 8, 11, 14, 17, 18, 19]).
-        should == [1..3, 6..8, 11..11, 14..14, 17..19]
+      expect(RangeSet.rangify([1, 2, 3, 6, 7, 8, 11, 14, 17, 18, 19])).
+        to eq([1..3, 6..8, 11..11, 14..14, 17..19])
     end
 
     it "should not rangify zero-length values when told to compress" do
-      RangeSet.rangify([1, 2, 3, 5, 8, 11, 12], true).
-        should == [1..3, 5, 8, 11..12]
+      expect(RangeSet.rangify([1, 2, 3, 5, 8, 11, 12], true)).
+        to eq([1..3, 5, 8, 11..12])
     end
   end
 
   describe "#to_a" do
     it "should return a copy of the ranges in the set" do
       set = RangeSet.new([1..10])
-      set.to_a.object_id.should_not == set.ranges.object_id
+      expect(set.to_a.object_id).not_to eq(set.ranges.object_id)
     end
 
     it "should return compressed ranges when asked" do
-      RangeSet.new([1..10, 12..12]).to_a(true).should == [1..10, 12]
+      expect(RangeSet.new([1..10, 12..12]).to_a(true)).to eq([1..10, 12])
     end
   end
 
   describe "#to_full_a" do
     it "expands all ranges" do
-      RangeSet.new([1..5]).to_full_a.should == [1, 2, 3, 4, 5]
+      expect(RangeSet.new([1..5]).to_full_a).to eq([1, 2, 3, 4, 5])
     end
   end
 
   describe "#new" do
     it "should flatten leading overlapping ranges" do
-      RangeSet.new([3..10, 1..8]).to_a.should == [1..10]
+      expect(RangeSet.new([3..10, 1..8]).to_a).to eq([1..10])
     end
 
     it "should flatten trailing overlapping ranges" do
-      RangeSet.new([1..10, 8..12]).to_a.should == [1..12]
+      expect(RangeSet.new([1..10, 8..12]).to_a).to eq([1..12])
     end
 
     it "should flatten completely overlapping ranges" do
-      RangeSet.new([2..3, 1..10]).to_a.should == [1..10]
+      expect(RangeSet.new([2..3, 1..10]).to_a).to eq([1..10])
     end
 
     it "should join ranges that are within 1 of each other" do
-      RangeSet.new([1..10, 11..15]).to_a.should == [1..15]
+      expect(RangeSet.new([1..10, 11..15]).to_a).to eq([1..15])
     end
   end
 
@@ -61,94 +61,94 @@ describe RangeSet do
         RangeSet.new([9..11, 1..2, 2..3, 14..18])
       )
 
-      set.to_a.should == [1..11, 14..18]
+      expect(set.to_a).to eq([1..11, 14..18])
     end
 
     it "should aggregate the ranges correctly even if they're given in reverse order" do
       set = RangeSet.new([3..10]).union(RangeSet.new([1..4]))
-      set.to_a.should == [1..10]
+      expect(set.to_a).to eq([1..10])
 
       set = RangeSet.new([1..4]).union(RangeSet.new([3..10]))
-      set.to_a.should == [1..10]
+      expect(set.to_a).to eq([1..10])
     end
   end
 
   describe "#intersection" do
     it "computes the intersection for leading overlapping ranges" do
       set = RangeSet.new([3..10]).intersection(RangeSet.new([1..7]))
-      set.to_a.should == [3..7]
+      expect(set.to_a).to eq([3..7])
     end
 
     it "computes the intersection for trailing overlapping ranges" do
       set = RangeSet.new([1..10]).intersection(RangeSet.new([5..15]))
-      set.to_a.should == [5..10]
+      expect(set.to_a).to eq([5..10])
     end
 
     it "computes the intersection for two completely overlapping ranges" do
       set = RangeSet.new([1..10]).intersection(RangeSet.new([3..6]))
-      set.to_a.should == [3..6]
+      expect(set.to_a).to eq([3..6])
     end
 
     it "returns an empty intersection if no elements exist in both ranges" do
       set = RangeSet.new([1..10]).intersection(RangeSet.new([15..20]))
-      set.to_a.should == []
+      expect(set.to_a).to eq([])
     end
 
     it "returns partial intersections when the range set contains multiple matching ranges" do
       set = RangeSet.new([1..5, 7..10]).intersection(RangeSet.new([3..8]))
-      set.to_a.should == [3..5, 7..8]
+      expect(set.to_a).to eq([3..5, 7..8])
     end
 
     it "doesn't matter what order the ranges are compared in" do
       set = RangeSet.new([2..3]).intersection(RangeSet.new([1..4]))
-      set.to_a.should == [2..3]
+      expect(set.to_a).to eq([2..3])
 
       set = RangeSet.new([1..4]).intersection(RangeSet.new([2..3]))
-      set.to_a.should == [2..3]
+      expect(set.to_a).to eq([2..3])
     end
   end
 
   describe "#subtract" do
     it "subtracts the intersection for leading overlapping ranges" do
       set = RangeSet.new([3..10]).subtract(RangeSet.new([1..5]))
-      set.to_a.should == [6..10]
+      expect(set.to_a).to eq([6..10])
     end
 
     it "subtracts the intersection for trailing overlapping ranges" do
       set = RangeSet.new([1..7]).subtract(RangeSet.new([3..9]))
-      set.to_a.should == [1..2]
+      expect(set.to_a).to eq([1..2])
     end
 
     it "subtracts the intersection for completely overlapping ranges (generates two ranges)" do
       set = RangeSet.new([1..10]).subtract(RangeSet.new([4..6]))
-      set.to_a.should == [1..3, 7..10]
+      expect(set.to_a).to eq([1..3, 7..10])
     end
 
     it "subtracts the intersection when the range set contians multiple matching ranges" do
       set = RangeSet.new([1..5, 7..10]).subtract(RangeSet.new([3..8]))
-      set.to_a.should == [1..2, 9..10]
+      expect(set.to_a).to eq([1..2, 9..10])
     end
 
     it "does not change object when subtracting an empty set" do
       set = RangeSet.new([1..5]).subtract(RangeSet.new([]))
-      set.to_a.should == [1..5]
+      expect(set.to_a).to eq([1..5])
     end
   end
 
   describe "#difference" do
     it "returns the symmetric difference (union - intersection) between completely overlapping ranges" do
       set = RangeSet.new([1..10]).difference(RangeSet.new([3..8]))
-      set.to_a.should == [1..2, 9..10]
+      expect(set.to_a).to eq([1..2, 9..10])
     end
 
     it "returns the symmetric difference between leading overlapping ranges" do
       set = RangeSet.new([3..10]).difference(RangeSet.new([1..5]))
-      set.to_a.should == [1..2, 6..10]
+      expect(set.to_a).to eq([1..2, 6..10])
     end
 
     it "returns the symmetric difference between trailing overlapping ranges" do
       set = RangeSet.new([1..5]).difference(RangeSet.new([3..8]))
-      set.to_a.should == [1..2, 6..8]
+      expect(set.to_a).to eq([1..2, 6..8])
     end
   end
 
@@ -156,16 +156,16 @@ describe RangeSet do
     let (:set) { RangeSet.new([1..5, 9..16]) }
 
     it "returns true if the set completely includes the range, false otherwise" do
-      set.should include(10..15)
-      set.should_not include(3..8)
-      set.should_not include(8..14)
+      expect(set).to include(10..15)
+      expect(set).not_to include(3..8)
+      expect(set).not_to include(8..14)
     end
 
     it "returns true if the set contains the value, false otherwise" do
-      set.should include(3)
-      set.should include(10)
-      set.should_not include(6)
-      set.should_not include(8)
+      expect(set).to include(3)
+      expect(set).to include(10)
+      expect(set).not_to include(6)
+      expect(set).not_to include(8)
     end
   end
 end

--- a/spec/utils/yaml/yaml_spec.rb
+++ b/spec/utils/yaml/yaml_spec.rb
@@ -81,7 +81,7 @@ describe TwitterCldr::Utils do
       'foobar'.localize.to_yaml(opt)
 
       # dump should not change the option hash
-      opt.should == { :syck_compatible => true }
+      expect(opt).to eq({ :syck_compatible => true })
 
       [
         [
@@ -113,7 +113,7 @@ describe TwitterCldr::Utils do
           "--- \n- \"\\xc2\\x86\"\n- \"a\\xe2\\x80\\xa8b\\xe2\\x80\\xa9c\"\n- \" abc\\n\\\n    xyz\"\n",
         ],
       ].each do |opt, yaml|
-        ["\xc2\x86", "a\xe2\x80\xa8b\xe2\x80\xa9c", " abc\nxyz"].localize.to_yaml(opt).should == yaml
+        expect(["\xc2\x86", "a\xe2\x80\xa8b\xe2\x80\xa9c", " abc\nxyz"].localize.to_yaml(opt)).to eq(yaml)
       end
     end
 
@@ -136,14 +136,14 @@ describe TwitterCldr::Utils do
           "--- \nb: 2\na: 1\nc: 3\n",
         ],
       ].each do |hash_order, yaml|
-        TwitterCldr::Utils::YAML.dump({ 'a' => 1, 'c' => 3, 'b' => 2 }, :hash_order => hash_order).should == yaml
+        expect(TwitterCldr::Utils::YAML.dump({ 'a' => 1, 'c' => 3, 'b' => 2 }, :hash_order => hash_order)).to eq(yaml)
       end
     end
 
     if RUBY_VERSION >= "1.9"
       it "should preserve hash order" do
         h = { 'a' => 1, 'c' => 3, 'b' => 2 }
-        TwitterCldr::Utils::YAML.dump(h, :preserve_order => true).should == "--- \na: 1\nc: 3\nb: 2\n"
+        expect(TwitterCldr::Utils::YAML.dump(h, :preserve_order => true)).to eq("--- \na: 1\nc: 3\nb: 2\n")
       end
     end
 
@@ -161,7 +161,7 @@ describe TwitterCldr::Utils do
         ["\r\xe2\x80\xa8\r\n", "--- \"\\n\\L\\n\"\n"],
         ["\r\xe2\x80\xa9\r\n", "--- \"\\n\\P\\n\"\n"],
       ].each do |src, yaml|
-        src.localize.to_yaml(:minimum_block_length => 16).should == yaml
+        expect(src.localize.to_yaml(:minimum_block_length => 16)).to eq(yaml)
       end
     end
 
@@ -170,7 +170,7 @@ describe TwitterCldr::Utils do
         [Struct.new('Hoge', :foo).new(123), "--- !ruby/struct:Hoge \n  foo: 123\n", ],
         [Struct.new(:foo).new(123),         "--- !ruby/struct: \n  foo: 123\n", ],
       ].each do |src, yaml|
-        TwitterCldr::Utils::YAML.dump(src).should == yaml
+        expect(TwitterCldr::Utils::YAML.dump(src)).to eq(yaml)
       end
     end
 
@@ -178,7 +178,7 @@ describe TwitterCldr::Utils do
       ("\x00".."\x7f").each do |c|
         y = c.localize.to_yaml
         r = YAML.load(y)
-        (c == "\r" ? "\n" : c).should == r  # "\r" is normalized as "\n"
+        expect(c == "\r" ? "\n" : c).to eq(r)  # "\r" is normalized as "\n"
       end
     end
 
@@ -215,7 +215,7 @@ describe TwitterCldr::Utils do
             )
 
             r = YAML.load(y)
-            (c == "\xc2\x85" ? "\n" : c).should == r  # "\N" is normalized as "\n"
+            expect(c == "\xc2\x85" ? "\n" : c).to eq(r)  # "\N" is normalized as "\n"
           end
         end
       end
@@ -287,9 +287,9 @@ describe TwitterCldr::Utils do
           r = YAML.load(y)
 
           if (RUBY_VERSION >= "2.0.0" || RUBY_PLATFORM == "java") && c.is_a?(String) && c.downcase == "null"
-            src.should == c + ext
+            expect(src).to eq(c + ext)
           else
-            src.should == r
+            expect(src).to eq(r)
           end
         end
       end
@@ -309,7 +309,7 @@ describe TwitterCldr::Utils do
         	      :escape_as_utf8      => true
         	    )
         	    r = YAML.load(y)
-        	    src.should == r
+        	    expect(src).to eq(r)
         	  end
         	end
         end
@@ -320,22 +320,22 @@ describe TwitterCldr::Utils do
     it "tests successful roundtrip_symbols" do
       symbol1 = :"Batman: The Dark Knight - Why So Serious?!"
       result_symbol1 = YAML.load(TwitterCldr::Utils::YAML.dump(symbol1))
-      symbol1.should == result_symbol1
+      expect(symbol1).to eq(result_symbol1)
 
       symbol2 = :"Batman: The Dark Knight - \"Why So Serious?!\""
       result_symbol2 = YAML.load(TwitterCldr::Utils::YAML.dump(symbol2))
-      symbol2.should == result_symbol2
+      expect(symbol2).to eq(result_symbol2)
     end
 
     it "tests successful roundtrip of natural symbols" do
       symbol1 = :"Batman: The Dark Knight - Why So Serious?!"
       result_symbol1 = YAML.load(TwitterCldr::Utils::YAML.dump(symbol1, :use_natural_symbols => true))
-      symbol1.should == result_symbol1
+      expect(symbol1).to eq(result_symbol1)
 
       symbol2 = :batman
-      TwitterCldr::Utils::YAML.dump(symbol2, :use_natural_symbols => true).should include(":batman")
+      expect(TwitterCldr::Utils::YAML.dump(symbol2, :use_natural_symbols => true)).to include(":batman")
       result_symbol2 = YAML.load(TwitterCldr::Utils::YAML.dump(symbol2, :use_natural_symbols => true))
-      symbol2.should == result_symbol2
+      expect(symbol2).to eq(result_symbol2)
     end
 
     it "tests successful roundtrip of mixed types" do
@@ -388,7 +388,7 @@ describe TwitterCldr::Utils do
         end
         y = TwitterCldr::Utils::YAML.dump(src, :syck_compatible => true)
         r = YAML.load(y)
-        src.should == r
+        expect(src).to eq(r)
       end
     end
 
@@ -417,7 +417,7 @@ describe TwitterCldr::Utils do
       ].each do |src|
         y = TwitterCldr::Utils::YAML.dump(src, :syck_compatible => true)
         r = YAML.load(y)
-        src.should == r
+        expect(src).to eq(r)
       end
     end
 
@@ -425,7 +425,7 @@ describe TwitterCldr::Utils do
       if RUBY_PLATFORM != "java"
         a = []
         a << a
-        lambda { TwitterCldr::Utils::YAML.dump(a) }.should raise_error(ArgumentError)
+        expect { TwitterCldr::Utils::YAML.dump(a) }.to raise_error(ArgumentError)
       end
     end
 
@@ -433,11 +433,11 @@ describe TwitterCldr::Utils do
       unless RUBY_VERSION < '1.9.0'
         y = nil
 
-        lambda { y = TwitterCldr::Utils::YAML.dump('日本語'.force_encoding('ASCII-8BIT')) }.should_not raise_error
-        y.should == "--- !binary |\n  5pel5pys6Kqe\n\n"
+        expect { y = TwitterCldr::Utils::YAML.dump('日本語'.force_encoding('ASCII-8BIT')) }.not_to raise_error
+        expect(y).to eq("--- !binary |\n  5pel5pys6Kqe\n\n")
 
-        lambda { y = TwitterCldr::Utils::YAML.dump('日本語'.encode('EUC-JP').force_encoding('UTF-8')) }.should_not raise_error
-        y.should == "--- !binary |\n  xvzL3Ljs\n\n"
+        expect { y = TwitterCldr::Utils::YAML.dump('日本語'.encode('EUC-JP').force_encoding('UTF-8')) }.not_to raise_error
+        expect(y).to eq("--- !binary |\n  xvzL3Ljs\n\n")
       end
     end
 

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -12,89 +12,89 @@ describe TwitterCldr::Utils do
     let(:symbolized_hash) { { :foo => { :bar => { :baz => 'woot' }, :ar => [1, 2] }, 42 => { :baz => 'wat' } } }
 
     it 'symbolizes string keys of a hash' do
-      TwitterCldr::Utils.deep_symbolize_keys(hash).should == symbolized_hash
+      expect(TwitterCldr::Utils.deep_symbolize_keys(hash)).to eq(symbolized_hash)
     end
 
     it 'deeply symbolizes elements of an array' do
-      TwitterCldr::Utils.deep_symbolize_keys([1, hash, 'foo', :bar]).should == [1, symbolized_hash, 'foo', :bar]
+      expect(TwitterCldr::Utils.deep_symbolize_keys([1, hash, 'foo', :bar])).to eq([1, symbolized_hash, 'foo', :bar])
     end
 
     it 'deeply symbolizes elements of an array nested in a hash' do
-      TwitterCldr::Utils.deep_symbolize_keys({ 'foo' => [1, hash] }).should == { :foo => [1, symbolized_hash] }
+      expect(TwitterCldr::Utils.deep_symbolize_keys({ 'foo' => [1, hash] })).to eq({ :foo => [1, symbolized_hash] })
     end
 
     it 'leaves arguments of other types alone' do
-      ['foo', :bar, 42].each { |arg| TwitterCldr::Utils.deep_symbolize_keys(arg).should == arg }
+      ['foo', :bar, 42].each { |arg| expect(TwitterCldr::Utils.deep_symbolize_keys(arg)).to eq(arg) }
     end
   end
 
   describe "#deep_merge! and #deep_merge_hash" do
     it "combines two non-nested hashes with different keys" do
       first = { :foo => "bar" }
-      TwitterCldr::Utils.deep_merge_hash(first, { :bar => "baz" }).should == { :foo => "bar", :bar => "baz" }
-      TwitterCldr::Utils.deep_merge!(first, { :bar => "baz" }).should == { :foo => "bar", :bar => "baz" }
+      expect(TwitterCldr::Utils.deep_merge_hash(first, { :bar => "baz" })).to eq({ :foo => "bar", :bar => "baz" })
+      expect(TwitterCldr::Utils.deep_merge!(first, { :bar => "baz" })).to eq({ :foo => "bar", :bar => "baz" })
     end
 
     it "combines two non-nested hashes with the same keys" do
       first = { :foo => "bar" }
-      TwitterCldr::Utils.deep_merge_hash(first, { :foo => "baz" }).should == { :foo => "baz" }
-      TwitterCldr::Utils.deep_merge!(first, { :foo => "baz" }).should == { :foo => "baz" }
+      expect(TwitterCldr::Utils.deep_merge_hash(first, { :foo => "baz" })).to eq({ :foo => "baz" })
+      expect(TwitterCldr::Utils.deep_merge!(first, { :foo => "baz" })).to eq({ :foo => "baz" })
     end
 
     it "combines two nested hashes" do
       first = { :foo => "bar", :second => { :bar => "baz", :twitter => "rocks" } }
       second = { :foo => "baz", :third => { :whassup => "cool" }, :second => { :twitter => "rules" } }
       result = { :foo => "baz", :second => { :bar => "baz", :twitter => "rules" }, :third => { :whassup => "cool" } }
-      TwitterCldr::Utils.deep_merge_hash(first, second).should == result
+      expect(TwitterCldr::Utils.deep_merge_hash(first, second)).to eq(result)
       TwitterCldr::Utils.deep_merge!(first, second)
-      first.should == result
+      expect(first).to eq(result)
     end
 
     it "replaces arrays with simple types" do
       first = [1, 2, 3]
-      TwitterCldr::Utils.deep_merge!(first, [4, 5, 6]).should == [4, 5, 6]
+      expect(TwitterCldr::Utils.deep_merge!(first, [4, 5, 6])).to eq([4, 5, 6])
     end
 
     it "merges a nested hash with a few simple array replacements" do
       first = { :foo => "bar", :second => { :bar => "baz", :twitter => [1, 2, 3] } }
       second = { :foo => [18], :third => { :whassup => "cool" }, :second => { :twitter => [4, 5, 6] } }
       TwitterCldr::Utils.deep_merge!(first, second)
-      first.should == { :foo => [18], :second => { :bar => "baz", :twitter => [4, 5, 6] }, :third => { :whassup => "cool" } }
+      expect(first).to eq({ :foo => [18], :second => { :bar => "baz", :twitter => [4, 5, 6] }, :third => { :whassup => "cool" } })
     end
 
     it "merges hashes within arrays" do
       first = [1, { :foo => "bar" }, { :bar => "baz" }, 8]
       second = [2, { :foo => "bar2" }, { :bar => "baz2", :twitter => "rules" }, 8, 9]
       TwitterCldr::Utils.deep_merge!(first, second)
-      first.should == [2, { :foo => "bar2" }, { :bar => "baz2", :twitter => "rules" }, 8, 9]
+      expect(first).to eq([2, { :foo => "bar2" }, { :bar => "baz2", :twitter => "rules" }, 8, 9])
     end
   end
 
   describe "#compute_cache_key" do
     it "returns a ruby hash of all the pieces concatenated with pipe characters" do
-      TwitterCldr::Utils.compute_cache_key("space", "the", "final", "frontier").should == "space|the|final|frontier".hash
+      expect(TwitterCldr::Utils.compute_cache_key("space", "the", "final", "frontier")).to eq("space|the|final|frontier".hash)
     end
 
     it "returns zero if no arguments are passed" do
-      TwitterCldr::Utils.compute_cache_key.should == 0
+      expect(TwitterCldr::Utils.compute_cache_key).to eq(0)
     end
   end
 
   describe '#traverse_hash' do
     it 'returns value from the hash at the given path' do
-      TwitterCldr::Utils.traverse_hash({ :foo => { :bar => 2, 'baz' => { 4 => 42 } } }, [:foo, 'baz', 4]).should == 42
+      expect(TwitterCldr::Utils.traverse_hash({ :foo => { :bar => 2, 'baz' => { 4 => 42 } } }, [:foo, 'baz', 4])).to eq(42)
     end
 
     it 'returns nil if the value is missing' do
-      TwitterCldr::Utils.traverse_hash({ :foo => { :bar => 2 } }, [:foo, :baz]).should be_nil
+      expect(TwitterCldr::Utils.traverse_hash({ :foo => { :bar => 2 } }, [:foo, :baz])).to be_nil
     end
 
     it 'returns nil path is empty' do
-      TwitterCldr::Utils.traverse_hash({ :foo => 42 }, []).should be_nil
+      expect(TwitterCldr::Utils.traverse_hash({ :foo => 42 }, [])).to be_nil
     end
 
     it 'returns nil if not a Hash is passed' do
-      TwitterCldr::Utils.traverse_hash(42, [:foo, :bar]).should be_nil
+      expect(TwitterCldr::Utils.traverse_hash(42, [:foo, :bar])).to be_nil
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 1291 conversions
  from: obj.should
    to: expect(obj).to
- 949 conversions
  from: == expected
    to: eq(expected)
- 51 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 37 conversions
  from: lambda { }.should
    to: expect { }.to
- 19 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
- 9 conversions
  from: =~ [1, 2]
    to: match_array([1, 2])
- 1 conversion
  from: =~ /pattern/
    to: match(/pattern/)

Update RSpec version
