### PR TITLE
Fixed a typo in `unicode_string.rb`

### DIFF
--- a/lib/twitter_cldr/parsers/unicode_regex/unicode_string.rb
+++ b/lib/twitter_cldr/parsers/unicode_regex/unicode_string.rb
@@ -32,7 +32,7 @@ module TwitterCldr
 
         def to_regexp_str
           cps = codepoints.is_a?(Array) ? codepoints : [codepoints]
-          array_to_regex(codepoints)
+          array_to_regex(cps)
         end
 
       end


### PR DESCRIPTION
- `cps` was being computed but not used. May lead to bugs in edge cases.
