### PR TITLE
Adding a test for the edge case in `unicode_string.rb`

### DIFF
--- a/spec/parsers/unicode_regex/unicode_string_spec.rb
+++ b/spec/parsers/unicode_regex/unicode_string_spec.rb
@@ -18,5 +18,10 @@ describe UnicodeRegexParser::UnicodeString do
       str = UnicodeRegexParser::UnicodeString.new([97, 98, 99])
       expect(str.to_set.to_a).to eq([[97, 98, 99]..[97, 98, 99]])
     end
+
+    it "should covert the codepoints to a valid regex" do
+      str = UnicodeRegexParser::UnicodeString.new(97)
+      expect(str.to_regexp_str).to eq"(?:\\141)"
+    end
   end
 end


### PR DESCRIPTION
- This test would fail if the typo from [130](https://github.com/twitter/twitter-cldr-rb/pull/130) was not corrected.
