### PR TITLE
Single quotes still appearing in date tokens, this fixes it

### DIFF
--- a/lib/twitter_cldr/tokenizers/calendars/date_time_tokenizer.rb
+++ b/lib/twitter_cldr/tokenizers/calendars/date_time_tokenizer.rb
@@ -68,6 +68,7 @@ module TwitterCldr
         @tokenizer ||= Tokenizer.new([
           TokenRecognizer.new(:date, /\{\{date\}\}/),
           TokenRecognizer.new(:time, /\{\{time\}\}/),
+          TokenRecognizer.new(:plaintext, /'.*'/),
           TokenRecognizer.new(:plaintext, //)
         ])
       end

--- a/spec/formatters/calendars/datetime_formatter_spec.rb
+++ b/spec/formatters/calendars/datetime_formatter_spec.rb
@@ -6,11 +6,20 @@
 require 'spec_helper'
 
 include TwitterCldr::Formatters
+include TwitterCldr::Tokenizers
 
 describe DateTimeFormatter do
   before(:each) do
     data_reader = TwitterCldr::DataReaders::DateTimeDataReader.new(:de)
     @formatter = DateTimeFormatter.new(data_reader)
+  end
+
+  describe 'plaintext' do
+    it "removes single quotes around plaintext tokens" do
+      tokens = [Token.new(:value => "'at'", :type => 'plaintext')]
+      date = Date.new(2010, 1, 10)
+      expect(@formatter.format(tokens, date, {})).to eq("at")
+    end
   end
 
   describe "#day" do

--- a/spec/localized/localized_datetime_spec.rb
+++ b/spec/localized/localized_datetime_spec.rb
@@ -11,7 +11,7 @@ describe LocalizedDateTime do
 
   let(:date_time) { DateTime.new(1987, 9, 20, 22, 5) }
 
-  describe '#initilize' do
+  describe '#initialize' do
     it 'sets calendar type' do
       expect(date_time.localize(:th, :calendar_type => :buddhist).calendar_type).to eq(:buddhist)
     end
@@ -39,6 +39,11 @@ describe LocalizedDateTime do
       date_time.localize(:th, :calendar_type => :buddhist).to_long_s
       date_time.localize(:th, :calendar_type => :buddhist).to_medium_s
       date_time.localize(:th, :calendar_type => :buddhist).to_short_s
+    end
+
+    it "should remove quotes around plaintext tokens" do
+      # notice there are no single quotes around the "at"
+      expect(date_time.localize(:en).to_long_s).to eq("September 20, 1987 at 10:05:00 PM UTC")
     end
   end
 


### PR DESCRIPTION
``` ruby
DateTime.now.localize(:en).to_long_s
```

currently returns: `September 10, 2014 'at' 9:36:18 PM UTC`. Those single quotes (i.e. 'at') are bad.
