### PR TITLE
Fix single quotes.

### DIFF
--- a/lib/twitter_cldr/formatters/formatter.rb
+++ b/lib/twitter_cldr/formatters/formatter.rb
@@ -23,11 +23,7 @@ module TwitterCldr
       protected
 
       def format_plaintext(token, index, obj, options)
-        if match = token.value.match(/([\s]*)'(.*)'([\s]*)/)
-          match.captures.join
-        else
-          token.value
-        end
+        token.value.gsub(/'([^']+)'/, '\1') # remove single-quote escaping for "real" characters
       end
 
       def format_composite(token, index, obj, options)

--- a/spec/localized/localized_datetime_spec.rb
+++ b/spec/localized/localized_datetime_spec.rb
@@ -98,6 +98,14 @@ describe LocalizedDateTime do
     it "should format using additional patterns" do
       expect(date_time.localize(:en).to_additional_s("EHms")).to eq("Sun 22:05:00")
     end
+
+    it "should properly handle single quotes escaping" do
+      expect(date_time.localize(:ru).to_additional_s("GyMMMd")).to eq("20 сент. 1987 г. н. э.")
+    end
+
+    it "should unescape multiple groups" do
+      expect(date_time.localize(:es).to_additional_s("yMMMd")).to eq("20 de sept. de 1987")
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
TwitterCLDR in master returns 

```
"20 сент. 1987 гн. э."
```

for 

```
date_time.localize(:ru).to_additional_s("GyMMMd")
```

that is not correct (missing dot and space).
