### PR TITLE
On February 2013 the Israel postcodes changed from 5 to 7-digit.

### DIFF
--- a/resources/shared/postal_codes.yml
+++ b/resources/shared/postal_codes.yml
@@ -631,7 +631,7 @@
     OkRpZ2l0BzsGWwA6EEBxdWFudGlmaWVybzouVHdpdHRlckNsZHI6OlV0aWxz
     OjpSZWdleHBBc3Q6OlF1YW50aWZpZXIHOglAbWF4aQo6CUBtaW5pCjsIMA==
 :il:
-  :regex: !ruby/regexp /\d{5}/
+  :regex: !ruby/regexp /\d{7}/
   :ast: |
     BAhvOihUd2l0dGVyQ2xkcjo6VXRpbHM6OlJlZ2V4cEFzdDo6Um9vdAc6EUBl
     eHByZXNzaW9uc1sGbzopVHdpdHRlckNsZHI6OlV0aWxzOjpSZWdleHBBc3Q6

--- a/resources/shared/postal_codes.yml
+++ b/resources/shared/postal_codes.yml
@@ -631,12 +631,14 @@
     OkRpZ2l0BzsGWwA6EEBxdWFudGlmaWVybzouVHdpdHRlckNsZHI6OlV0aWxz
     OjpSZWdleHBBc3Q6OlF1YW50aWZpZXIHOglAbWF4aQo6CUBtaW5pCjsIMA==
 :il:
-  :regex: !ruby/regexp /\d{7}/
+  :regex: !ruby/regexp /\d{5}(?:\d{2})?/
   :ast: |
     BAhvOihUd2l0dGVyQ2xkcjo6VXRpbHM6OlJlZ2V4cEFzdDo6Um9vdAc6EUBl
-    eHByZXNzaW9uc1sGbzopVHdpdHRlckNsZHI6OlV0aWxzOjpSZWdleHBBc3Q6
+    eHByZXNzaW9uc1sHbzopVHdpdHRlckNsZHI6OlV0aWxzOjpSZWdleHBBc3Q6
     OkRpZ2l0BzsGWwA6EEBxdWFudGlmaWVybzouVHdpdHRlckNsZHI6OlV0aWxz
-    OjpSZWdleHBBc3Q6OlF1YW50aWZpZXIHOglAbWF4aQo6CUBtaW5pCjsIMA==
+    OjpSZWdleHBBc3Q6OlF1YW50aWZpZXIHOglAbWF4aQo6CUBtaW5pCm86K1R3
+    aXR0ZXJDbGRyOjpVdGlsczo6UmVnZXhwQXN0OjpQYXNzaXZlBzsGWwZvOwcH
+    OwZbADsIbzsJBzsKaQc7C2kHOwhvOwkHOwppBjsLaQA7CDA=
 :im:
   :regex: !ruby/regexp /IM\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}/
   :ast: |


### PR DESCRIPTION
"Starting on February 2013 the Israel postcodes change from 5 to 7-digit. The 5-Digit codes will be valid until 31. January 2013."