### PR TITLE
Fix invalid unicode regex behavior

### DIFF
--- a/lib/twitter_cldr/parsers/parser.rb
+++ b/lib/twitter_cldr/parsers/parser.rb
@@ -44,6 +44,10 @@ module TwitterCldr
       def current_token
         @tokens[@token_index]
       end
+
+      def eof?
+        @token_index >= @tokens.size
+      end
     end
 
   end

--- a/lib/twitter_cldr/parsers/unicode_regex/character_class.rb
+++ b/lib/twitter_cldr/parsers/unicode_regex/character_class.rb
@@ -50,6 +50,10 @@ module TwitterCldr
           evaluate(root)
         end
 
+        def codepoints
+          codepoints_from(root)
+        end
+
         def to_s
           stringify(root)
         end
@@ -57,6 +61,17 @@ module TwitterCldr
         private
 
         attr_reader :root
+
+        def codepoints_from(node)
+          case node
+            when UnaryOperator
+              codepoints_from(node.child)
+            when BinaryOperator
+              codepoints_from(node.left) + codepoints_from(node.right)
+            else
+              node.codepoints
+          end
+        end
 
         def stringify(node)
           case node

--- a/lib/twitter_cldr/parsers/unicode_regex/character_range.rb
+++ b/lib/twitter_cldr/parsers/unicode_regex/character_range.rb
@@ -33,6 +33,10 @@ module TwitterCldr
           )
         end
 
+        def codepoints
+          to_set.to_full_a
+        end
+
         def to_s
           "#{initial.to_s}-#{final.to_s}"
         end

--- a/lib/twitter_cldr/shared/properties_database.rb
+++ b/lib/twitter_cldr/shared/properties_database.rb
@@ -79,6 +79,10 @@ module TwitterCldr
           path.split(File::SEPARATOR).join if path
         end.compact
 
+        if name_indicates_value_prefix?(property_name)
+          values += values.map { |v| v[0] }
+        end
+
         property_values[property_name] = if values.length == 0
           nil
         else

--- a/lib/twitter_cldr/tokenizers/tokenizer.rb
+++ b/lib/twitter_cldr/tokenizers/tokenizer.rb
@@ -49,7 +49,7 @@ module TwitterCldr
           Regexp.compile(
             tokenizers.map do |tokenizer|
               tokenizer.custom_splitter.source
-            end.join("|")
+            end.join("|"), nil, 'u'
           )
         end
 
@@ -79,17 +79,19 @@ module TwitterCldr
             recognizer.recognizes?(token_text)
           end
 
-          if recognizer.token_type == :composite
-            content = token_text.match(recognizer.content)[1]
-            ret << CompositeToken.new(tokenize(content))
-          else
-            cleaned_text = recognizer.clean(token_text)
+          if recognizer
+            if recognizer.token_type == :composite
+              content = token_text.match(recognizer.content)[1]
+              ret << CompositeToken.new(tokenize(content))
+            else
+              cleaned_text = recognizer.clean(token_text)
 
-            if (remove_empty_entries && cleaned_text.size > 0) || !remove_empty_entries
-              ret << Token.new(
-                value: cleaned_text,
-                type: recognizer.token_type
-              )
+              if (remove_empty_entries && cleaned_text.size > 0) || !remove_empty_entries
+                ret << Token.new(
+                  value: cleaned_text,
+                  type: recognizer.token_type
+                )
+              end
             end
           end
 

--- a/lib/twitter_cldr/tokenizers/unicode_regex/unicode_regex_tokenizer.rb
+++ b/lib/twitter_cldr/tokenizers/unicode_regex/unicode_regex_tokenizer.rb
@@ -21,8 +21,8 @@ module TwitterCldr
           recognizers = [
             # The variable name can contain letters and digits, but must start with a letter.
             TokenRecognizer.new(:variable, /\$\w[\w\d]*/),
-            TokenRecognizer.new(:character_set, /\[:[\w\s]+:\]|\\p\{[\w=]+\}/),  # [:Lu:] or \p{Lu} or \p{Sentence_Break=CF}
-            TokenRecognizer.new(:negated_character_set, /\[:\^[\w\s]+:\]|\\P\{[\w=]+\}/),  #[:^Lu:] or \P{Lu}
+            TokenRecognizer.new(:character_set, /\[:[\w\s=]+:\]|\\p\{[\w\s=]+\}/),  # [:Lu:] or \p{Lu} or \p{Sentence_Break=CF}
+            TokenRecognizer.new(:negated_character_set, /\[:\^[\w\s=]+:\]|\\P\{[\w\s=]+\}/),  #[:^Lu:] or \P{Lu}
             TokenRecognizer.new(:unicode_char, /\\u\{?[a-fA-F0-9]{1,6}\}?/),
             TokenRecognizer.new(:multichar_string, /\{\w+\}/u),
 
@@ -38,7 +38,7 @@ module TwitterCldr
             TokenRecognizer.new(:open_bracket, /\[/),
             TokenRecognizer.new(:close_bracket, /\]/),
 
-            TokenRecognizer.new(:string, //) do |val|
+            TokenRecognizer.new(:string, //u) do |val|
               val == " " ? val : val.strip
             end
           ]

--- a/lib/twitter_cldr/utils/range_set.rb
+++ b/lib/twitter_cldr/utils/range_set.rb
@@ -175,6 +175,12 @@ module TwitterCldr
         end
       end
 
+      def size
+        ranges.inject(0) do |sum, range|
+          sum + range.size
+        end
+      end
+
       private
 
       def includes_numeric?(num)

--- a/spec/shared/code_point_spec.rb
+++ b/spec/shared/code_point_spec.rb
@@ -64,7 +64,7 @@ describe CodePoint do
       properties = code_point.properties
       expect(properties.alphabetic).to be_true
       expect(properties.script).to eq(Set.new(%w(Latin)))
-      expect(properties.general_category).to eq(Set.new(%w(Lu)))
+      expect(properties.general_category).to eq(Set.new(%w(L Lu)))
     end
   end
 

--- a/spec/shared/properties_database_spec.rb
+++ b/spec/shared/properties_database_spec.rb
@@ -89,7 +89,7 @@ describe PropertiesDatabase do
       it 'returns a property set for the given code point' do
         property_set = database.properties_for_code_point(65)
         expect(property_set).to be_a(PropertySet)
-        expect(property_set.general_category).to eq(Set.new(%w(Lu)))
+        expect(property_set.general_category).to eq(Set.new(%w(L Lu)))
         expect(property_set.word_break).to eq(Set.new(%w(ALetter)))
       end
     end

--- a/spec/shared/unicode_regex_spec.rb
+++ b/spec/shared/unicode_regex_spec.rb
@@ -210,6 +210,13 @@ describe UnicodeRegex do
         expect(regex).to exactly_match(",")
         expect(regex).not_to exactly_match("a")
       end
+
+      it "should treat a dash that is the first character of a character class as a literal dash instead of a range" do
+        regex = compile("[-abc]*")
+        expect(regex).to exactly_match("a-b-c")
+        expect(regex).to exactly_match("--a")
+        expect(regex).not_to exactly_match("def")
+      end
     end
   end
 end


### PR DESCRIPTION
Unicode regexes currently have the following issues:

1. The regex `/[[:L:][:White_Space:]]/` raises a `UnicodeRegexParserError` because it thinks `White_Space` isn't a valid unicode property (surprise: it is).
2. Putting in an equals sign avoids the error, but doesn't correctly match word and whitespace characters. `'a b c _ d'.gsub(UnicodeRegex.compile('[[:L:][:=White_Space:]]'), '')` returns `" b   d"`, expected `"_"`
3. While it is true that negating the regex matches the opposite characters in the test string, the wrong characters are matched. `'a b c _ d'.gsub(UnicodeRegex.compile('[^[:L:][:=White_Space:]]'), '')` returns `"ac_"`, expected: `"a b c  d"`
4. A dash as the first character of a character class is treated as a range. I had previously thought this to be correct behavior, but it turns out most regex engines allow a leading dash to be treated as a literal dash. `'n-m'.gsub(UnicodeRegex.compile('[-abcd]').to_regexp, '')` returns `"n-m"`, expected `"nm"`.