### PR TITLE
Update the south korean postcode validation from 6 to 5 digits

### DIFF
--- a/resources/shared/postal_codes.yml
+++ b/resources/shared/postal_codes.yml
@@ -814,19 +814,12 @@
     OkRpZ2l0BzsGWwA6EEBxdWFudGlmaWVybzouVHdpdHRlckNsZHI6OlV0aWxz
     OjpSZWdleHBBc3Q6OlF1YW50aWZpZXIHOglAbWF4aQo6CUBtaW5pCjsIMA==
 :kr:
-  :regex: !ruby/regexp /\d{3}(?:\d{2}|[\-]\d{3})/
+  :regex: !ruby/regexp /\d{5}/
   :ast: |
     BAhvOihUd2l0dGVyQ2xkcjo6VXRpbHM6OlJlZ2V4cEFzdDo6Um9vdAc6EUBl
-    eHByZXNzaW9uc1sHbzopVHdpdHRlckNsZHI6OlV0aWxzOjpSZWdleHBBc3Q6
+    eHByZXNzaW9uc1sGbzopVHdpdHRlckNsZHI6OlV0aWxzOjpSZWdleHBBc3Q6
     OkRpZ2l0BzsGWwA6EEBxdWFudGlmaWVybzouVHdpdHRlckNsZHI6OlV0aWxz
-    OjpSZWdleHBBc3Q6OlF1YW50aWZpZXIHOglAbWF4aQg6CUBtaW5pCG86K1R3
-    aXR0ZXJDbGRyOjpVdGlsczo6UmVnZXhwQXN0OjpQYXNzaXZlBzsGWwZvOi9U
-    d2l0dGVyQ2xkcjo6VXRpbHM6OlJlZ2V4cEFzdDo6QWx0ZXJuYXRpb24HOwZb
-    B286LFR3aXR0ZXJDbGRyOjpVdGlsczo6UmVnZXhwQXN0OjpTZXF1ZW5jZQc7
-    BlsGbzsHBzsGWwA7CG87CQc7CmkHOwtpBzsIMG87Dgc7BlsHbzowVHdpdHRl
-    ckNsZHI6OlV0aWxzOjpSZWdleHBBc3Q6OkNoYXJhY3RlclNldAk6DUBtZW1i
-    ZXJzWwYiBi06DUBuZWdhdGVkRjsGWwA7CDBvOwcHOwZbADsIbzsJBzsKaQg7
-    C2kIOwgwOwgwOwgwOwgw
+    OjpSZWdleHBBc3Q6OlF1YW50aWZpZXIHOglAbWF4aQo6CUBtaW5pCjsIMA==
 :kw:
   :regex: !ruby/regexp /\d{5}/
   :ast: |


### PR DESCRIPTION
Fix for: #195 

From August the 1st 2015 South Korea's postcode went from being 6 digits to 5

Which causes issues for anyone using the library to validate addresses for delivery, as the api that this library uses still supports the old postcode as well as the new one:

 /\d{3}(?:\d{2}|[\-]\d{3})/

where it should be

 /\d{5}/
