### PR TITLE
Pass along locale when formatting currencies.

### DIFF
--- a/lib/twitter_cldr/data_readers/number_data_reader.rb
+++ b/lib/twitter_cldr/data_readers/number_data_reader.rb
@@ -55,6 +55,8 @@ module TwitterCldr
         precision = options[:precision] || 0
         pattern_for_number = pattern(number, precision == 0)
 
+        options[:locale] = self.locale
+
         if pattern_for_number == '0'
           # there's no specific formatting for the number in the current locale
           number.to_s

--- a/lib/twitter_cldr/formatters/numbers/currency_formatter.rb
+++ b/lib/twitter_cldr/formatters/numbers/currency_formatter.rb
@@ -9,6 +9,7 @@ module TwitterCldr
 
       def format(tokens, number, options = {})
         options[:currency] ||= "USD"
+        options[:locale] ||= :en
         currency = TwitterCldr::Shared::Currencies.for_code(options[:currency], options[:locale])
         currency ||= {
           currency:    options[:currency],

--- a/lib/twitter_cldr/formatters/numbers/currency_formatter.rb
+++ b/lib/twitter_cldr/formatters/numbers/currency_formatter.rb
@@ -9,7 +9,7 @@ module TwitterCldr
 
       def format(tokens, number, options = {})
         options[:currency] ||= "USD"
-        currency = TwitterCldr::Shared::Currencies.for_code(options[:currency])
+        currency = TwitterCldr::Shared::Currencies.for_code(options[:currency], options[:locale])
         currency ||= {
           currency:    options[:currency],
           symbol:      options[:currency],

--- a/spec/localized/localized_number_spec.rb
+++ b/spec/localized/localized_number_spec.rb
@@ -112,6 +112,12 @@ describe LocalizedNumber do
       it 'should not overwrite precision when explicitly passed' do
         expect(number.to_s(precision: 1)).to eq("$10.0")
       end
+
+      let(:number) { LocalizedNumber.new(10, :"en-AU", type: :currency) }
+
+      it "it should respect number's locale when picking currency symbol" do
+        expect(number.to_s(currency: "USD", use_cldr_symbol: true)).to eq("USD10.00")
+      end
     end
 
     context 'percentages' do


### PR DESCRIPTION
The currency symbol depends on the locale (e.g. USD uses "USD" not "$" in en-AU).