### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/twitter_cldr.gemspec
+++ b/twitter_cldr.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.authors  = ["Cameron Dutro"]
   s.email    = ["cdutro@twitter.com"]
   s.homepage = "http://twitter.com"
+  s.license  = "Apache-2.0"
 
   s.description = s.summary = "Ruby implementation of the ICU (International Components for Unicode) that uses the Common Locale Data Repository to format dates, plurals, and more."
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.