### PR TITLE
Add missing postal code for Liechtenstein

### DIFF
--- a/resources/shared/postal_codes.yml
+++ b/resources/shared/postal_codes.yml
@@ -878,7 +878,7 @@
     cmFsCDoKQHRleHRJIgYgBjoGRVQ7BlsAOwlvOwoHOwtpBjsMaQBvOwcHOwZb
     Bm87CAc7BlsAOwlvOwoHOwtpCTsMaQk7CTA7CW87Cgc7C2kGOwxpADsJMA==
 :li:
-  :regex: !ruby/regexp /948[5-9]|949[0-7]/
+  :regex: !ruby/regexp /948[5-9]|949[0-8]/
   :ast: |
     BAhvOihUd2l0dGVyQ2xkcjo6VXRpbHM6OlJlZ2V4cEFzdDo6Um9vdAc6EUBl
     eHByZXNzaW9uc1sGbzovVHdpdHRlckNsZHI6OlV0aWxzOjpSZWdleHBBc3Q6


### PR DESCRIPTION
Postal codes in Liechtenstein go to `9498`, see https://en.wikipedia.org/wiki/Postal_codes_in_Switzerland_and_Liechtenstein#Liechtenstein