### PR TITLE
Fix encoding warning

### DIFF
--- a/lib/twitter_cldr/tokenizers/tokenizer.rb
+++ b/lib/twitter_cldr/tokenizers/tokenizer.rb
@@ -49,7 +49,7 @@ module TwitterCldr
           Regexp.compile(
             tokenizers.map do |tokenizer|
               tokenizer.custom_splitter.source
-            end.join("|"), nil, 'u'
+            end.join("|")
           )
         end
 


### PR DESCRIPTION
I was getting the following warning:

gems/twitter_cldr-4.4.2/lib/twitter_cldr/tokenizers/tokenizer.rb:49: warning: encoding option is ignored - u

`Regexp` hasn't supported the `u` option, or anything but the `n` option since Ruby 1.8