### PR TITLE
Provide file encoding explicitly in resource loader

### DIFF
--- a/lib/twitter_cldr/resources/loader.rb
+++ b/lib/twitter_cldr/resources/loader.rb
@@ -106,13 +106,12 @@ module TwitterCldr
         file_path = absolute_resource_path(path)
 
         if File.file?(file_path)
-          File.read(file_path)
+          File.open(file_path, "r:UTF-8", &:read)
         else
           raise ResourceLoadError,
             "Resource '#{path}' not found."
         end
       end
-
     end
 
   end

--- a/spec/resources/loader_spec.rb
+++ b/spec/resources/loader_spec.rb
@@ -178,7 +178,7 @@ describe Loader do
 
   def stub_resource_file(resource_path, content)
     file_path = File.join(TwitterCldr::RESOURCES_DIR, resource_path)
-    allow(File).to receive(:read).with(file_path).and_return(content)
+    allow(File).to receive(:open).with(file_path, "r:UTF-8").and_return(content)
     allow(File).to receive(:file?).with(file_path).and_return(true)
   end
 


### PR DESCRIPTION
I faced with encoding issue on windows. 

Code `3.localize(:zh).spellout` produce `Σ╕ë` on unix it works properly and return `三`

This PR fix encoding issue on windows