### PR TITLE
Use https instead of http in urls

### DIFF
--- a/lib/twitter_cldr/resources/language_codes_importer.rb
+++ b/lib/twitter_cldr/resources/language_codes_importer.rb
@@ -13,8 +13,8 @@ module TwitterCldr
       BCP_47_FILE, ISO_639_FILE = %w[bcp-47.txt iso-639.txt]
 
       INPUT_DATA = {
-        BCP_47_FILE  => 'http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry',
-        ISO_639_FILE => 'http://www-01.sil.org/iso639-3/iso-639-3_20120614.tab'
+        BCP_47_FILE  => 'https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry',
+        ISO_639_FILE => 'https://www-01.sil.org/iso639-3/iso-639-3_20120614.tab'
       }
 
       KEYS_TO_STANDARDS = {

--- a/lib/twitter_cldr/resources/postal_codes_importer.rb
+++ b/lib/twitter_cldr/resources/postal_codes_importer.rb
@@ -12,7 +12,7 @@ module TwitterCldr
 
     class PostalCodesImporter < Importer
 
-      BASE_URL = 'http://i18napis.appspot.com/address/data/'
+      BASE_URL = 'https://i18napis.appspot.com/address/data/'
 
       output_path 'shared'
       ruby_engine :mri

--- a/lib/twitter_cldr/resources/requirements/cldr_requirement.rb
+++ b/lib/twitter_cldr/resources/requirements/cldr_requirement.rb
@@ -12,7 +12,7 @@ module TwitterCldr
     module Requirements
 
       class CldrRequirement
-        CLDR_URL = "http://unicode.org/Public/cldr/%{version}/core.zip"
+        CLDR_URL = "https://unicode.org/Public/cldr/%{version}/core.zip"
 
         attr_reader :version
 

--- a/lib/twitter_cldr/resources/requirements/icu_requirement.rb
+++ b/lib/twitter_cldr/resources/requirements/icu_requirement.rb
@@ -15,7 +15,7 @@ module TwitterCldr
       # first on the classpath wins, which can be surprising if you're not
       # expecting it. Oh, and it can break all the tests.
       class IcuRequirement
-        ICU_URL = "http://download.icu-project.org/files/icu4j/%{version}/icu4j-%{underscored_version}.jar"
+        ICU_URL = "https://download.icu-project.org/files/icu4j/%{version}/icu4j-%{underscored_version}.jar"
 
         # first entry is JCL itself, other two are JCL dependencies
         JCL_JARS = [

--- a/lib/twitter_cldr/resources/uli/segment_exceptions_importer.rb
+++ b/lib/twitter_cldr/resources/uli/segment_exceptions_importer.rb
@@ -12,7 +12,7 @@ module TwitterCldr
     module Uli
       class SegmentExceptionsImporter < Resources::Importer
 
-        URL = "http://unicode.org/uli/trac/export/58/trunk/abbrs/json/%{locale}.json"
+        URL = "https://unicode.org/uli/trac/export/58/trunk/abbrs/json/%{locale}.json"
         LOCALES = [:de, :en, :es, :fr, :it, :pt, :ru]   # these are the only locales ULI supports at the moment
 
         output_path 'uli/segments'

--- a/spec/collation/collation_spec.rb
+++ b/spec/collation/collation_spec.rb
@@ -14,7 +14,7 @@ describe 'Unicode Collation Algorithm' do
   SHORT_COLLATION_TEST_PATH = File.join(File.dirname(__FILE__), 'CollationTest_CLDR_NON_IGNORABLE_Short.txt')
   FULL_COLLATION_TEST_PATH  = File.join(File.dirname(__FILE__), 'CollationTest_CLDR_NON_IGNORABLE.txt')
 
-  FULL_COLLATION_TEST_URL = 'http://unicode.org/Public/UCA/latest/CollationAuxiliary.zip'
+  FULL_COLLATION_TEST_URL = 'https://unicode.org/Public/UCA/latest/CollationAuxiliary.zip'
 
   it 'passes all the tests in CollationTest_CLDR_NON_IGNORABLE_Short.txt' do
     run_test(SHORT_COLLATION_TEST_PATH)

--- a/spec/segmentation/break_iterator_spec.rb
+++ b/spec/segmentation/break_iterator_spec.rb
@@ -30,10 +30,10 @@ describe BreakIterator do
     end
 
     it "does not split periods in the midst of other letters, eg. in a URL" do
-      str = "Visit us. Go to http://translate.twitter.com."
+      str = "Visit us. Go to https://translate.twitter.com."
       expect(iterator.each_sentence(str).map { |word, _, _| word }).to eq([
         "Visit us. ",
-        "Go to http://translate.twitter.com."
+        "Go to https://translate.twitter.com."
       ])
     end
 

--- a/twitter_cldr.gemspec
+++ b/twitter_cldr.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version  = ::TwitterCldr::VERSION
   s.authors  = ["Cameron Dutro"]
   s.email    = ["cdutro@twitter.com"]
-  s.homepage = "http://twitter.com"
+  s.homepage = "https://twitter.com"
   s.license  = "Apache-2.0"
 
   s.description = s.summary = "Ruby implementation of the ICU (International Components for Unicode) that uses the Common Locale Data Repository to format dates, plurals, and more."


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.