### PR TITLE
Fix infinite recursion affecting certain Russian RBNF rule sets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.2.9
-  - 2.4.3
-  - 2.5.0
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - jruby-head
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TwitterCldr Changelog
 
+### 4.4.5 (August 11, 2019)
+* Fix infinite recursion bug affecting certain Russian RBNF rule sets (and
+  possibly other locales).
+
 ### 4.4.4 (April 1, 2019)
 * Explicitly set encoding in resource loader to fix encoding bug on Windows.
 

--- a/docker_tests.sh
+++ b/docker_tests.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+tags=( 2.0.0-p643-slim 2.1.10-slim 2.2.10-slim 2.3.8-slim 2.4.6-slim 2.5.5-slim 2.6.3-slim )
+
+for tag in "${tags[@]}"
+do
+  docker run --rm \
+    -v $PWD:/usr/src/app \
+    -w /usr/src/app \
+    -e RUBYOPT="-E UTF-8" \
+    ruby:$tag /bin/sh -c "apt-get update && apt-get install -y git build-essential patch ruby-dev zlib1g-dev liblzma-dev libxml2 libxslt1-dev && gem install bundler -v 1.17.3 && bundle install && bundle exec rake spec:full"
+done

--- a/lib/twitter_cldr/formatters/numbers/rbnf/formatters.rb
+++ b/lib/twitter_cldr/formatters/numbers/rbnf/formatters.rb
@@ -115,6 +115,11 @@ module TwitterCldr
           token.value
         end
 
+        # if a decimal token occurs here, it's actually plaintext
+        def decimal(number, rule, token)
+          token.value
+        end
+
         def semicolon(number, rule, token)
           ""
         end

--- a/lib/twitter_cldr/formatters/numbers/rbnf/rule_parser.rb
+++ b/lib/twitter_cldr/formatters/numbers/rbnf/rule_parser.rb
@@ -59,6 +59,10 @@ module TwitterCldr
           switch(list)
         end
 
+        def decimal(list)
+          add_and_advance(list)
+        end
+
         def plaintext(list)
           add_and_advance(list)
         end

--- a/lib/twitter_cldr/tokenizers/numbers/rbnf_tokenizer.rb
+++ b/lib/twitter_cldr/tokenizers/numbers/rbnf_tokenizer.rb
@@ -29,7 +29,7 @@ module TwitterCldr
             TokenRecognizer.new(:left_arrow, /</),
             TokenRecognizer.new(:open_bracket, /\[/),
             TokenRecognizer.new(:close_bracket, /\]/),
-            TokenRecognizer.new(:decimal, /[0#][0#,\.]+/),
+            TokenRecognizer.new(:decimal, /[0#][0#,\.]*/),
             TokenRecognizer.new(:plural, /\$\(.*\)\$/),
 
             # ending

--- a/lib/twitter_cldr/version.rb
+++ b/lib/twitter_cldr/version.rb
@@ -4,5 +4,5 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 module TwitterCldr
-  VERSION = '4.4.4'
+  VERSION = '4.4.5'
 end

--- a/twitter_cldr.gemspec
+++ b/twitter_cldr.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.description = s.summary = "Ruby implementation of the ICU (International Components for Unicode) that uses the Common Locale Data Repository to format dates, plurals, and more."
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.summary  = "Ruby implementation of the ICU (International Components for Unicode) that uses the Common Locale Data Repository to format dates, plurals, and more."
 
   # json gem since v2.0 requries Ruby ~> 2.0


### PR DESCRIPTION
Could potentially be affecting other languages as well. Russian's `spellout-ordinal-masculine` rule set contains `=0=.;` as the last rule. Up until now, TwitterCLDR treated the `0` token as plaintext when in reality it's a decimal format indicator designed to spit back the original number (followed by a period) for any number greater than 21000. The change is simply to adjust the tokenizer to treat `0` as a decimal format instruction.