### PR TITLE
convert_locale falls back to language

### DIFF
--- a/lib/twitter_cldr.rb
+++ b/lib/twitter_cldr.rb
@@ -114,7 +114,16 @@ module TwitterCldr
     def convert_locale(locale)
       locale = locale.to_sym if locale.respond_to?(:to_sym)
       locale = lowercase_locales_map.fetch(locale, locale)
-      TWITTER_LOCALE_MAP.fetch(locale, locale)
+      locale = TWITTER_LOCALE_MAP.fetch(locale, locale)
+
+      unless TwitterCldr.supported_locale?(locale)
+        language = locale.split('-')[0]
+        if TwitterCldr.supported_locale?(language)
+          locale = language
+        end
+      end
+
+      locale
     end
 
     def twitter_locale(locale)

--- a/lib/twitter_cldr.rb
+++ b/lib/twitter_cldr.rb
@@ -113,7 +113,7 @@ module TwitterCldr
 
     def convert_locale(locale)
       locale = locale.to_sym if locale.respond_to?(:to_sym)
-      locale = lowercase_locales_map.fetch(locale, locale)
+      locale = locale.downcase
       locale = TWITTER_LOCALE_MAP.fetch(locale, locale)
 
       unless TwitterCldr.supported_locale?(locale)
@@ -155,14 +155,6 @@ module TwitterCldr
         return result if result
       end
       nil
-    end
-
-    def lowercase_locales_map
-      @lowercase_locales_map ||= supported_locales.inject({}) do |memo, locale|
-        lowercase = locale.to_s.downcase.to_sym
-        memo[lowercase] = locale unless lowercase == locale
-        memo
-      end
     end
 
   end

--- a/lib/twitter_cldr.rb
+++ b/lib/twitter_cldr.rb
@@ -112,20 +112,23 @@ module TwitterCldr
     end
 
     def convert_locale(locale)
-      locale = explicit_convert_locale(locale)
+      locale = normalize_locale(locale)
 
-      unless TwitterCldr.supported_locale?(locale)
-        language = locale.to_s.split('-')[0]
-        language = language.to_sym if language.respond_to?(:to_sym)
-        if TwitterCldr.supported_locale?(language)
-          locale = language
+      unless supported_locale?(locale)
+        loc = TwitterCldr::Shared::Locale.parse(locale)
+        max_supported = loc.max_supported
+
+        if loc.dasherized == 'und' || !max_supported
+          return locale
         end
+
+        locale = normalize_locale(max_supported.dasherized)
       end
 
       locale
     end
 
-    def explicit_convert_locale(locale)
+    def normalize_locale(locale)
       return locale unless (locale.is_a?(String) || locale.is_a?(Symbol))
 
       locale = locale.to_sym
@@ -143,7 +146,7 @@ module TwitterCldr
     end
 
     def supported_locale?(locale)
-      !!locale && supported_locales.include?(explicit_convert_locale(locale))
+      !!locale && supported_locales.include?(normalize_locale(locale))
     end
 
     protected

--- a/lib/twitter_cldr/shared/locale.rb
+++ b/lib/twitter_cldr/shared/locale.rb
@@ -3,7 +3,6 @@
 # Copyright 2012 Twitter, Inc
 # http://www.apache.org/licenses/LICENSE-2.0
 
-require 'set'
 
 module TwitterCldr
   module Shared

--- a/lib/twitter_cldr/shared/locale.rb
+++ b/lib/twitter_cldr/shared/locale.rb
@@ -3,7 +3,6 @@
 # Copyright 2012 Twitter, Inc
 # http://www.apache.org/licenses/LICENSE-2.0
 
-
 module TwitterCldr
   module Shared
     class Locale

--- a/lib/twitter_cldr/shared/locale.rb
+++ b/lib/twitter_cldr/shared/locale.rb
@@ -3,6 +3,8 @@
 # Copyright 2012 Twitter, Inc
 # http://www.apache.org/licenses/LICENSE-2.0
 
+require 'set'
+
 module TwitterCldr
   module Shared
     class Locale

--- a/spec/formatters/plurals/plural_formatter_spec.rb
+++ b/spec/formatters/plurals/plural_formatter_spec.rb
@@ -195,7 +195,7 @@ describe TwitterCldr::Formatters::PluralFormatter do
 
   describe '#pluralization_rule' do
     it 'delegates pluralization rule fetching to Rules.rule_for method' do
-      expect(TwitterCldr::Formatters::Plurals::Rules).to receive(:rule_for).with(42, :jp).and_return('result')
+      expect(TwitterCldr::Formatters::Plurals::Rules).to receive(:rule_for).with(42, :ja).and_return('result')
       expect(described_class.new(:jp).send(:pluralization_rule, 42)).to eq('result')
     end
   end

--- a/spec/shared/calendar_spec.rb
+++ b/spec/shared/calendar_spec.rb
@@ -28,7 +28,7 @@ describe TwitterCldr::Shared::Calendar do
     end
 
     it 'returns calendar for a specific locale' do
-      expect(described_class.new(:jp).locale).to eq(:jp)
+      expect(described_class.new(:jp).locale).to eq(:ja)
     end
 
     it 'uses TwitterCldr.convert_locale' do

--- a/spec/shared/numbers_spec.rb
+++ b/spec/shared/numbers_spec.rb
@@ -10,8 +10,8 @@ describe TwitterCldr::Shared::Numbers do
     let(:symbols) { { nan: 'NaN', minus_sign: '-' } }
 
     it 'returns numerical symbols for default locale' do
-      allow(TwitterCldr).to receive(:locale).and_return(:jp)
-      allow(TwitterCldr).to receive(:get_locale_resource).with(:jp, :numbers).and_return(jp: { numbers: { symbols: symbols } })
+      allow(TwitterCldr).to receive(:locale).and_return(:ja)
+      allow(TwitterCldr).to receive(:get_locale_resource).with(:ja, :numbers).and_return(ja: { numbers: { symbols: symbols } })
       expect(described_class.symbols).to eq(symbols)
     end
 

--- a/spec/twitter_cldr_spec.rb
+++ b/spec/twitter_cldr_spec.rb
@@ -55,6 +55,17 @@ describe TwitterCldr do
       expect(TwitterCldr.convert_locale(:'zh-tw')).to eq(:'zh-Hant')
     end
 
+    it "should fallback to language if locale is unsupported but language is" do
+      expect(TwitterCldr.convert_locale(:'pt-BR')).to eq(:pt)
+      expect(TwitterCldr.convert_locale(:'zh-Hans-CN')).to eq(:zh)
+      expect(TwitterCldr.convert_locale(:'zz-ZZ')).to eq(:'zz-ZZ')
+    end
+
+    it "should leave known locales alone" do
+      expect(TwitterCldr.convert_locale(:fr)).to eq(:fr)
+      expect(TwitterCldr.convert_locale(:'fr-CA')).to eq(:'fr-CA')
+    end
+
     it "should leave unknown locales alone" do
       expect(TwitterCldr.convert_locale(:blarg)).to eq(:blarg)
     end

--- a/spec/twitter_cldr_spec.rb
+++ b/spec/twitter_cldr_spec.rb
@@ -53,21 +53,30 @@ describe TwitterCldr do
       expect(TwitterCldr.convert_locale(:msa)).to eq(:ms)
       expect(TwitterCldr.convert_locale(:'zh-cn')).to eq(:zh)
       expect(TwitterCldr.convert_locale(:'zh-tw')).to eq(:'zh-Hant')
+      expect(TwitterCldr.convert_locale(:'zh-TW')).to eq(:'zh-Hant')
     end
 
     it "should fallback to language if locale is unsupported but language is" do
       expect(TwitterCldr.convert_locale(:'pt-BR')).to eq(:pt)
       expect(TwitterCldr.convert_locale(:'zh-Hans-CN')).to eq(:zh)
-      expect(TwitterCldr.convert_locale(:'zz-ZZ')).to eq(:'zz-ZZ')
     end
 
     it "should leave known locales alone" do
       expect(TwitterCldr.convert_locale(:fr)).to eq(:fr)
       expect(TwitterCldr.convert_locale(:'fr-CA')).to eq(:'fr-CA')
+      expect(TwitterCldr.convert_locale(:'es-419')).to eq(:'es-419')
     end
 
     it "should leave unknown locales alone" do
       expect(TwitterCldr.convert_locale(:blarg)).to eq(:blarg)
+      expect(TwitterCldr.convert_locale(:'zz-ZZ')).to eq(:'zz-ZZ')
+    end
+
+    it "shouldn't blowup on bad input" do
+      expect(TwitterCldr.convert_locale(5)).to eq(5)
+      expect(TwitterCldr.convert_locale([])).to eq([])
+      expect(TwitterCldr.convert_locale("")).to eq(:"")
+      expect(TwitterCldr.convert_locale(nil)).to eq(nil)
     end
   end
 

--- a/spec/twitter_cldr_spec.rb
+++ b/spec/twitter_cldr_spec.rb
@@ -63,6 +63,7 @@ describe TwitterCldr do
 
     it "should leave known locales alone" do
       expect(TwitterCldr.convert_locale(:fr)).to eq(:fr)
+      expect(TwitterCldr.convert_locale(:'fr-ca')).to eq(:'fr-CA')
       expect(TwitterCldr.convert_locale(:'fr-CA')).to eq(:'fr-CA')
       expect(TwitterCldr.convert_locale(:'es-419')).to eq(:'es-419')
     end
@@ -75,7 +76,7 @@ describe TwitterCldr do
     it "shouldn't blowup on bad input" do
       expect(TwitterCldr.convert_locale(5)).to eq(5)
       expect(TwitterCldr.convert_locale([])).to eq([])
-      expect(TwitterCldr.convert_locale("")).to eq(:"")
+      expect(TwitterCldr.convert_locale('')).to eq(:'')
       expect(TwitterCldr.convert_locale(nil)).to eq(nil)
     end
   end


### PR DESCRIPTION
## Summary
Right now, if you use a valid BCP-47 code that has multiple parts (i.e. `de-DE`) that is unsupported, TwitterCLDR falls back to the default locale. This change has it try the language (i.e. `de`) first before falling back to default.

## Future improvements
This change is not robust to certain edge cases. Some examples:
- `zh-Hant-TW` should fall back to `zh-Hant`, not `zh`
- `es-CR` should fall back to `es-419`, not `es`
