### PR TITLE
support BigDecimal in number localization

### DIFF
--- a/lib/twitter_cldr/core_ext.rb
+++ b/lib/twitter_cldr/core_ext.rb
@@ -1,9 +1,10 @@
 # encoding: UTF-8
+require "bigdecimal"
 
 # Copyright 2012 Twitter, Inc
 # http://www.apache.org/licenses/LICENSE-2.0
 
-[Integer, Float].each do |klass|
+[Integer, Float, BigDecimal].each do |klass|
   TwitterCldr::Localized::LocalizedNumber.localize(klass)
 end
 

--- a/lib/twitter_cldr/formatters/numbers/number_formatter.rb
+++ b/lib/twitter_cldr/formatters/numbers/number_formatter.rb
@@ -69,24 +69,33 @@ module TwitterCldr
         precision = options[:precision] || precision_from(number)
         rounding = options[:rounding] || 0
 
-        number = "%.#{precision}f" % round_to(number, precision, rounding).abs
+        if number.is_a? BigDecimal
+          number = round_to(number, precision, rounding).abs.round(precision).to_s("F")
+        else
+          number = "%.#{precision}f" % round_to(number, precision, rounding).abs
+        end
         number.split(".")
       end
 
       def round_to(number, precision, rounding = 0)
         factor = 10 ** precision
-        result = (number * factor).round.to_f / factor
+        result = number.is_a?(BigDecimal) ?
+          ((number * factor).round(0) / factor) :
+          ((number * factor).round.to_f / factor)
 
         if rounding > 0
           rounding = rounding.to_f / factor
-          result = (result *  (1.0 / rounding)).round.to_f / (1.0 / rounding)
+          result = number.is_a?(BigDecimal) ?
+            ((result *  (1.0 / rounding)).round(0) / (1.0 / rounding)) :
+            ((result *  (1.0 / rounding)).round.to_f / (1.0 / rounding))
         end
 
         result
       end
 
       def precision_from(num)
-        parts = num.to_s.split(".")
+        return 0 if num.is_a?(BigDecimal) && num.fix == num
+        parts = (num.is_a?(BigDecimal) ? num.to_s("F") : num.to_s ).split(".")
         parts.size == 2 ? parts[1].size : 0
       end
 

--- a/lib/twitter_cldr/formatters/numbers/number_formatter.rb
+++ b/lib/twitter_cldr/formatters/numbers/number_formatter.rb
@@ -70,7 +70,9 @@ module TwitterCldr
         rounding = options[:rounding] || 0
 
         if number.is_a? BigDecimal
-          number = round_to(number, precision, rounding).abs.round(precision).to_s("F")
+          number = precision == 0 ?
+            round_to(number, precision, rounding).abs.fix.to_s("F") :
+            round_to(number, precision, rounding).abs.round(precision).to_s("F")
         else
           number = "%.#{precision}f" % round_to(number, precision, rounding).abs
         end
@@ -80,13 +82,13 @@ module TwitterCldr
       def round_to(number, precision, rounding = 0)
         factor = 10 ** precision
         result = number.is_a?(BigDecimal) ?
-          ((number * factor).round(0) / factor) :
+          ((number * factor).fix / factor) :
           ((number * factor).round.to_f / factor)
 
         if rounding > 0
           rounding = rounding.to_f / factor
           result = number.is_a?(BigDecimal) ?
-            ((result *  (1.0 / rounding)).round(0) / (1.0 / rounding)) :
+            ((result *  (1.0 / rounding)).fix / (1.0 / rounding)) :
             ((result *  (1.0 / rounding)).round.to_f / (1.0 / rounding))
         end
 

--- a/spec/localized/localized_number_spec.rb
+++ b/spec/localized/localized_number_spec.rb
@@ -100,6 +100,27 @@ describe TwitterCldr::Localized::LocalizedNumber do
       end
     end
 
+    context 'big decimals' do
+      let(:integer) { described_class.new(BigDecimal("123456789012345678901234567890"), :en) }
+      let(:decimal) { described_class.new(BigDecimal("123456789012345678901234567890.123"), :en) }
+
+      it 'should default precision to zero' do
+        expect(integer.to_s).to eq("123,456,789,012,345,678,901,234,567,890")
+      end
+
+      it 'should not overwrite precision when explicitly passed' do
+        expect(integer.to_s(precision: 2)).to eq("123,456,789,012,345,678,901,234,567,890.00")
+      end
+
+      it 'should default precision to that of the supplied number' do
+        expect(decimal.to_s).to eq("123,456,789,012,345,678,901,234,567,890.123")
+      end
+
+      it 'should not overwrite precision when explicitly passed' do
+        expect(decimal.to_s(precision: 2)).to eq("123,456,789,012,345,678,901,234,567,890.12")
+      end
+    end
+
     context 'currencies' do
       let(:number) { described_class.new(10, :en, type: :currency) }
 

--- a/spec/localized/localized_number_spec.rb
+++ b/spec/localized/localized_number_spec.rb
@@ -112,6 +112,10 @@ describe TwitterCldr::Localized::LocalizedNumber do
         expect(integer.to_s(precision: 2)).to eq("123,456,789,012,345,678,901,234,567,890.00")
       end
 
+      it 'should not truncate big decimal when precision set to zero (Ruby 3.0 issue)' do
+        expect(integer.to_s(precision: 0)).to eq("123,456,789,012,345,678,901,234,567,890")
+      end
+
       it 'should default precision to that of the supplied number' do
         expect(decimal.to_s).to eq("123,456,789,012,345,678,901,234,567,890.123")
       end


### PR DESCRIPTION
This PR adds support to BigDecimal alongside Float and Int as a class of number that can undergo localization. This is necessary in contexts where arbitrary precision numbers need to be localized.