### PR TITLE
Import list formats considering ancestor locales and fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # TwitterCldr Changelog
 
+### 6.6.1
+* Fix bug causing blank strings when formatting lists (#241)
+
 ### 6.6.0 (March 25th, 2021)
 * Support BigDecimal in number localization (#240, @opoudjis)
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :development, :test do
   gem 'rake'
-  gem 'pry-nav'
+  gem 'pry-byebug'
   gem 'ruby-prof' unless RUBY_PLATFORM == 'java'
   gem 'regexp_parser', '~> 0.5'
   gem 'benchmark-ips'

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ require 'rubygems/package_task'
 
 require './lib/twitter_cldr'
 
-require 'pry-nav'
+require 'pry-byebug'
 
 Bundler::GemHelper.install_tasks
 
@@ -87,6 +87,11 @@ namespace :update do
   desc 'Import number formats'
   task :number_formats do
     TwitterCldr::Resources::NumberFormatsImporter.new.import
+  end
+
+  desc 'Import list formats'
+  task :list_formats do
+    TwitterCldr::Resources::ListFormatsImporter.new.import
   end
 
   desc 'Import currency symbols'

--- a/lib/twitter_cldr/resources.rb
+++ b/lib/twitter_cldr/resources.rb
@@ -17,6 +17,7 @@ module TwitterCldr
     autoload :Importer,                       'twitter_cldr/resources/importer'
     autoload :ImportResolver,                 'twitter_cldr/resources/import_resolver'
     autoload :LanguageCodesImporter,          'twitter_cldr/resources/language_codes_importer'
+    autoload :ListFormatsImporter,            'twitter_cldr/resources/list_formats_importer'
     autoload :Loader,                         'twitter_cldr/resources/loader'
     autoload :LocalesResourcesImporter,       'twitter_cldr/resources/locales_resources_importer'
     autoload :NumberFormatsImporter,          'twitter_cldr/resources/number_formats_importer'
@@ -58,6 +59,7 @@ module TwitterCldr
           DayPeriodRulesImporter,
           HyphenationImporter,
           LanguageCodesImporter,
+          ListFormatsImporter,
           LocalesResourcesImporter,
           NumberFormatsImporter,
           ParentLocalesImporter,

--- a/lib/twitter_cldr/resources/list_formats_importer.rb
+++ b/lib/twitter_cldr/resources/list_formats_importer.rb
@@ -1,0 +1,108 @@
+# encoding: UTF-8
+
+# Copyright 2012 Twitter, Inc
+# http://www.apache.org/licenses/LICENSE-2.0
+
+require 'nokogiri'
+require 'parallel'
+require 'etc'
+require 'set'
+
+module TwitterCldr
+  module Resources
+
+    class ListFormatsImporter < Importer
+
+      requirement :cldr, Versions.cldr_version
+      output_path 'locales'
+      locales TwitterCldr.supported_locales
+      ruby_engine :mri
+
+      private
+
+      def execute
+        locales = Set.new
+
+        finish = -> (locale, *) do
+          locales.add(locale)
+          STDOUT.write "\rImported #{locale}, #{locales.size} of #{params[:locales].size} total"
+        end
+
+        Parallel.each(params[:locales], in_processes: Etc.nprocessors, finish: finish) do |locale|
+          import_locale(locale)
+          locales << locale
+        end
+      end
+
+      def import_locale(locale)
+        data = requirements[:cldr].merge_each_ancestor(locale) do |ancestor_locale|
+          ListFormats.new(ancestor_locale, requirements[:cldr]).to_h
+        end
+
+        output_file = File.join(output_path, locale.to_s, 'lists.yml')
+
+        File.open(output_file, 'w:utf-8') do |output|
+          output.write(
+            TwitterCldr::Utils::YAML.dump(
+              TwitterCldr::Utils.deep_symbolize_keys(locale => data),
+              use_natural_symbols: true
+            )
+          )
+        end
+      end
+
+      def output_path
+        params.fetch(:output_path)
+      end
+
+    end
+
+
+    class ListFormats
+
+      attr_reader :locale, :cldr_req
+
+      def initialize(locale, cldr_req)
+        @locale = locale
+        @cldr_req = cldr_req
+      end
+
+      def to_h
+        { lists: lists }
+      end
+
+      def lists
+        doc.xpath('//ldml/listPatterns/listPattern').each_with_object({}) do |pattern_node, pattern_result|
+          pattern_type = if attribute = pattern_node.attribute('type')
+            attribute.value.to_sym
+          else
+            :default
+          end
+
+          if aliased = pattern_node.xpath('alias').first
+            alias_type = aliased.attribute('path').value[/@type='([\w-]+)'/, 1]
+            pattern_result[pattern_type] = :"lists.#{alias_type || 'default'}"
+            next
+          end
+
+          pattern_result[pattern_type] = pattern_node.xpath('listPatternPart').each_with_object({}) do |type_node, type_result|
+            type_result[type_node.attribute('type').value.to_sym] = type_node.content
+          end
+        end
+      end
+
+      def doc
+        @doc ||= begin
+          locale_fs = locale.to_s.gsub('-', '_')
+          Nokogiri.XML(File.read(File.join(cldr_main_path, "#{locale_fs}.xml")))
+        end
+      end
+
+      def cldr_main_path
+        @cldr_main_path ||= File.join(cldr_req.common_path, 'main')
+      end
+
+    end
+
+  end
+end

--- a/lib/twitter_cldr/resources/locales_resources_importer.rb
+++ b/lib/twitter_cldr/resources/locales_resources_importer.rb
@@ -26,7 +26,6 @@ module TwitterCldr
         languages
         currencies
         plural_rules
-        lists
         rbnf
         units
         fields

--- a/lib/twitter_cldr/version.rb
+++ b/lib/twitter_cldr/version.rb
@@ -4,5 +4,5 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 
 module TwitterCldr
-  VERSION = '6.6.0'
+  VERSION = '6.6.1'
 end

--- a/resources/locales/af/lists.yml
+++ b/resources/locales/af/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} of {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} en {1}"

--- a/resources/locales/be/lists.yml
+++ b/resources/locales/be/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} ці {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} і {1}"

--- a/resources/locales/bg/lists.yml
+++ b/resources/locales/bg/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} или {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/bn/lists.yml
+++ b/resources/locales/bn/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, বা {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/bo/lists.yml
+++ b/resources/locales/bo/lists.yml
@@ -13,10 +13,10 @@
       :end: "{0}, or {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
-    :standard-short: {}
-    :unit: {}
-    :unit-narrow: {}
-    :unit-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
+    :standard-short: :lists.default
+    :unit: :lists.unit-short
+    :unit-narrow: :lists.unit-short
+    :unit-short: :lists.default

--- a/resources/locales/bs/lists.yml
+++ b/resources/locales/bs/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} ili {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} i {1}"

--- a/resources/locales/ca/lists.yml
+++ b/resources/locales/ca/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/cy/lists.yml
+++ b/resources/locales/cy/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} neu {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/da/lists.yml
+++ b/resources/locales/da/lists.yml
@@ -21,7 +21,7 @@
       ? !ruby/symbol "2"
       : "{0} el. {1}"
       :end: "{0} el. {1}"
-    :standard-narrow: {}
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} og {1}"

--- a/resources/locales/de-AT/lists.yml
+++ b/resources/locales/de-AT/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} oder {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} und {1}"

--- a/resources/locales/de-CH/lists.yml
+++ b/resources/locales/de-CH/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} oder {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} und {1}"

--- a/resources/locales/de/lists.yml
+++ b/resources/locales/de/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} oder {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} und {1}"

--- a/resources/locales/el/lists.yml
+++ b/resources/locales/el/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ή {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/en-US/lists.yml
+++ b/resources/locales/en-US/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, or {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/en/lists.yml
+++ b/resources/locales/en/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, or {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/eo/lists.yml
+++ b/resources/locales/eo/lists.yml
@@ -13,10 +13,10 @@
       :end: "{0}, or {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
-    :standard-short: {}
-    :unit: {}
-    :unit-narrow: {}
-    :unit-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
+    :standard-short: :lists.default
+    :unit: :lists.unit-short
+    :unit-narrow: :lists.unit-short
+    :unit-short: :lists.default

--- a/resources/locales/es-419/lists.yml
+++ b/resources/locales/es-419/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} y {1}"

--- a/resources/locales/es-AR/lists.yml
+++ b/resources/locales/es-AR/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} y {1}"

--- a/resources/locales/es-CO/lists.yml
+++ b/resources/locales/es-CO/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} y {1}"

--- a/resources/locales/es-MX/lists.yml
+++ b/resources/locales/es-MX/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} y {1}"

--- a/resources/locales/es-US/lists.yml
+++ b/resources/locales/es-US/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} y {1}"

--- a/resources/locales/es/lists.yml
+++ b/resources/locales/es/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} y {1}"

--- a/resources/locales/et/lists.yml
+++ b/resources/locales/et/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} või {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/eu/lists.yml
+++ b/resources/locales/eu/lists.yml
@@ -13,13 +13,13 @@
       :end: "{0} edo {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"
       :end: "{0}, {1}"
-    :standard-short: {}
+    :standard-short: :lists.default
     :unit: 
       ? !ruby/symbol "2"
       : "{0} eta {1}"

--- a/resources/locales/fi/lists.yml
+++ b/resources/locales/fi/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} tai {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} ja {1}"

--- a/resources/locales/fil/lists.yml
+++ b/resources/locales/fil/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/fr-BE/lists.yml
+++ b/resources/locales/fr-BE/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ou {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/fr-CA/lists.yml
+++ b/resources/locales/fr-CA/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ou {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/fr-CH/lists.yml
+++ b/resources/locales/fr-CH/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ou {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/fr/lists.yml
+++ b/resources/locales/fr/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ou {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/gl/lists.yml
+++ b/resources/locales/gl/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ou {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       :middle: "{0}, {1}"
       :start: "{0}, {1}"

--- a/resources/locales/gu/lists.yml
+++ b/resources/locales/gu/lists.yml
@@ -13,7 +13,7 @@
       :end: "{0}, અથવા {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
+    :or-narrow: :lists.or-short
     :or-short: 
       :end: "{0} અથવા {1}"
     :standard-narrow: 

--- a/resources/locales/he/lists.yml
+++ b/resources/locales/he/lists.yml
@@ -17,7 +17,7 @@
       :end: "{0} או {1}"
     :or-short: 
       :end: "{0} או {1}"
-    :standard-narrow: {}
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} ו{1}"

--- a/resources/locales/hi/lists.yml
+++ b/resources/locales/hi/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} या {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} और {1}"

--- a/resources/locales/hr/lists.yml
+++ b/resources/locales/hr/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} ili {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} i {1}"

--- a/resources/locales/hu/lists.yml
+++ b/resources/locales/hu/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} vagy {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} és {1}"

--- a/resources/locales/hy/lists.yml
+++ b/resources/locales/hy/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} կամ {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/id/lists.yml
+++ b/resources/locales/id/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, atau {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/is/lists.yml
+++ b/resources/locales/is/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} eða {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/it-CH/lists.yml
+++ b/resources/locales/it-CH/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} e {1}"

--- a/resources/locales/it/lists.yml
+++ b/resources/locales/it/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} o {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} e {1}"

--- a/resources/locales/ja/lists.yml
+++ b/resources/locales/ja/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0}、または{1}"
       :middle: "{0}、{1}"
       :start: "{0}、{1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0}、{1}"

--- a/resources/locales/ka/lists.yml
+++ b/resources/locales/ka/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} ან {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} და {1}"

--- a/resources/locales/kk/lists.yml
+++ b/resources/locales/kk/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0}, не болмаса {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} және {1}"

--- a/resources/locales/km/lists.yml
+++ b/resources/locales/km/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ឬ {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/kn/lists.yml
+++ b/resources/locales/kn/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, ಅಥವಾ {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/ko/lists.yml
+++ b/resources/locales/ko/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} 또는 {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} 및 {1}"

--- a/resources/locales/lo/lists.yml
+++ b/resources/locales/lo/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ຫຼື {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       :end: "{0}, {1}"
     :standard-short: 

--- a/resources/locales/lt/lists.yml
+++ b/resources/locales/lt/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} ar {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} ir {1}"

--- a/resources/locales/lv/lists.yml
+++ b/resources/locales/lv/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} vai {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} un {1}"

--- a/resources/locales/mk/lists.yml
+++ b/resources/locales/mk/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} или {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0} и {1}"

--- a/resources/locales/mr/lists.yml
+++ b/resources/locales/mr/lists.yml
@@ -13,10 +13,10 @@
       :end: "{0}, किंवा {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
+    :or-narrow: :lists.or-short
     :or-short: 
       :end: "{0} किंवा {1}"
-    :standard-narrow: {}
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} आणि {1}"

--- a/resources/locales/ms/lists.yml
+++ b/resources/locales/ms/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, atau {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/mt/lists.yml
+++ b/resources/locales/mt/lists.yml
@@ -13,10 +13,10 @@
       :end: "{0}, or {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
-    :standard-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
+    :standard-short: :lists.default
     :unit: 
       ? !ruby/symbol "2"
       : "{0} u {1}"

--- a/resources/locales/nb/lists.yml
+++ b/resources/locales/nb/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} eller {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} og {1}"

--- a/resources/locales/nl-BE/lists.yml
+++ b/resources/locales/nl-BE/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} of {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} en {1}"

--- a/resources/locales/nl/lists.yml
+++ b/resources/locales/nl/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} of {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} en {1}"

--- a/resources/locales/pl/lists.yml
+++ b/resources/locales/pl/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} lub {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0} i {1}"

--- a/resources/locales/pt-PT/lists.yml
+++ b/resources/locales/pt-PT/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ou {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/pt/lists.yml
+++ b/resources/locales/pt/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} ou {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/ro/lists.yml
+++ b/resources/locales/ro/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} sau {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/ru/lists.yml
+++ b/resources/locales/ru/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} или {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/sk/lists.yml
+++ b/resources/locales/sk/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} alebo {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} a {1}"

--- a/resources/locales/sl/lists.yml
+++ b/resources/locales/sl/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} ali {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} in {1}"

--- a/resources/locales/sq/lists.yml
+++ b/resources/locales/sq/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} ose {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} dhe {1}"

--- a/resources/locales/sr-Cyrl-ME/lists.yml
+++ b/resources/locales/sr-Cyrl-ME/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} или {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} и {1}"

--- a/resources/locales/sr-Latn-ME/lists.yml
+++ b/resources/locales/sr-Latn-ME/lists.yml
@@ -3,40 +3,40 @@
   :lists: 
     :default: 
       ? !ruby/symbol "2"
-      : "{0} и {1}"
-      :end: "{0} и {1}"
+      : "{0} i {1}"
+      :end: "{0} i {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
     :or: 
       ? !ruby/symbol "2"
-      : "{0} или {1}"
-      :end: "{0} или {1}"
+      : "{0} ili {1}"
+      :end: "{0} ili {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
-      : "{0} и {1}"
-      :end: "{0} и {1}"
+      : "{0} i {1}"
+      :end: "{0} i {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
     :unit: 
       ? !ruby/symbol "2"
-      : "{0} и {1}"
-      :end: "{0} и {1}"
+      : "{0} i {1}"
+      :end: "{0} i {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
     :unit-narrow: 
       ? !ruby/symbol "2"
-      : "{0} и {1}"
-      :end: "{0} и {1}"
+      : "{0} i {1}"
+      :end: "{0} i {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
     :unit-short: 
       ? !ruby/symbol "2"
-      : "{0} и {1}"
-      :end: "{0} и {1}"
+      : "{0} i {1}"
+      :end: "{0} i {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"

--- a/resources/locales/sr/lists.yml
+++ b/resources/locales/sr/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0} или {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0} и {1}"

--- a/resources/locales/sv/lists.yml
+++ b/resources/locales/sv/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} eller {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/ta/lists.yml
+++ b/resources/locales/ta/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} அல்லது {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0} மற்றும் {1}"

--- a/resources/locales/tr/lists.yml
+++ b/resources/locales/tr/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} veya {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/uk/lists.yml
+++ b/resources/locales/uk/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} або {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/resources/locales/ur/lists.yml
+++ b/resources/locales/ur/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}، یا {1}"
       :middle: "{0}، {1}"
       :start: "{0}، {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}، {1}"

--- a/resources/locales/vi/lists.yml
+++ b/resources/locales/vi/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0} hoặc {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"
@@ -25,7 +25,7 @@
       ? !ruby/symbol "2"
       : "{0} và {1}"
       :end: "{0} và {1}"
-    :unit: {}
+    :unit: :lists.unit-short
     :unit-narrow: 
       ? !ruby/symbol "2"
       : "{0} {1}"

--- a/resources/locales/xh/lists.yml
+++ b/resources/locales/xh/lists.yml
@@ -13,10 +13,10 @@
       :end: "{0}, or {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
-    :standard-short: {}
-    :unit: {}
-    :unit-narrow: {}
-    :unit-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
+    :standard-short: :lists.default
+    :unit: :lists.unit-short
+    :unit-narrow: :lists.unit-short
+    :unit-short: :lists.default

--- a/resources/locales/zh-Hant/lists.yml
+++ b/resources/locales/zh-Hant/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0}或{1}"
       :middle: "{0}、{1}"
       :start: "{0}、{1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0}和{1}"

--- a/resources/locales/zh/lists.yml
+++ b/resources/locales/zh/lists.yml
@@ -13,9 +13,9 @@
       :end: "{0}或{1}"
       :middle: "{0}、{1}"
       :start: "{0}、{1}"
-    :or-narrow: {}
-    :or-short: {}
-    :standard-narrow: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
+    :standard-narrow: :lists.standard-short
     :standard-short: 
       ? !ruby/symbol "2"
       : "{0}和{1}"

--- a/resources/locales/zu/lists.yml
+++ b/resources/locales/zu/lists.yml
@@ -13,8 +13,8 @@
       :end: "{0}, or {1}"
       :middle: "{0}, {1}"
       :start: "{0}, {1}"
-    :or-narrow: {}
-    :or-short: {}
+    :or-narrow: :lists.or-short
+    :or-short: :lists.or
     :standard-narrow: 
       ? !ruby/symbol "2"
       : "{0}, {1}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@
 
 require 'rspec'
 require 'twitter_cldr'
-require 'pry-nav'
+require 'pry-byebug'
 require 'coveralls'
 require 'eprun'
 


### PR DESCRIPTION
See: https://github.com/twitter/twitter-cldr-rb/issues/241

The legacy importing code that uses the ruby-cldr gem doesn't properly merge together all the resources in the locale's ancestor chain. I've been slowly rewriting the legacy importers, but it's slow going. This PR specifically fixes the list format importer and thereby addresses the linked issue. Portuguese (and all other) list formats should work as expected once this is merged.