### PR TITLE
Fix ambiguous time issue

### DIFF
--- a/lib/twitter_cldr/timezones/generic_location.rb
+++ b/lib/twitter_cldr/timezones/generic_location.rb
@@ -21,18 +21,18 @@ module TwitterCldr
       Territories = TwitterCldr::Shared::Territories
       Utils = TwitterCldr::Utils
 
-      def display_name_for(date, fmt = :generic_location)
+      def display_name_for(date, fmt = :generic_location, dst = TZInfo::Timezone.default_dst, &block)
         case fmt
           when :generic_location
             generic_location_display_name
           when :generic_short
-            generic_short_display_name(date) || generic_location_display_name
+            generic_short_display_name(date, dst, &block) || generic_location_display_name
           when :generic_long
-            generic_long_display_name(date) || generic_location_display_name
+            generic_long_display_name(date, dst, &block) || generic_location_display_name
           when :specific_short
-            specific_short_display_name(date)
+            specific_short_display_name(date, dst, &block)
           when :specific_long
-            specific_long_display_name(date)
+            specific_long_display_name(date, dst, &block)
           when :exemplar_location
             exemplar_city
           else
@@ -58,20 +58,20 @@ module TwitterCldr
         end
       end
 
-      def generic_short_display_name(date)
-        format_display_name(date, :generic, :short)
+      def generic_short_display_name(date, dst = TZInfo::Timezone.default_dst, &block)
+        format_display_name(date, :generic, :short, dst, &block)
       end
 
-      def generic_long_display_name(date)
-        format_display_name(date, :generic, :long)
+      def generic_long_display_name(date, dst = TZInfo::Timezone.default_dst, &block)
+        format_display_name(date, :generic, :long, dst, &block)
       end
 
-      def specific_short_display_name(date)
-        format_display_name(date, :specific, :short)
+      def specific_short_display_name(date, dst = TZInfo::Timezone.default_dst, &block)
+        format_display_name(date, :specific, :short, dst, &block)
       end
 
-      def specific_long_display_name(date)
-        format_display_name(date, :specific, :long)
+      def specific_long_display_name(date, dst = TZInfo::Timezone.default_dst, &block)
+        format_display_name(date, :specific, :long, dst, &block)
       end
 
       # From ICU source, TimeZoneGenericNames.java, formatGenericNonLocationName():
@@ -86,9 +86,9 @@ module TwitterCldr
       # 4. If a generic non-location string is not available, use generic location
       #    string.
       #
-      def format_display_name(date, type, fmt)
+      def format_display_name(date, type, fmt, dst = TZInfo::Timezone.default_dst, &block)
         date_int = date.strftime('%s').to_i
-        period = get_period_for_naming(date)
+        period = tz.period_for_local(date, dst, &block)
 
         flavor = if type == :generic
           :generic

--- a/lib/twitter_cldr/timezones/generic_location.rb
+++ b/lib/twitter_cldr/timezones/generic_location.rb
@@ -88,7 +88,7 @@ module TwitterCldr
       #
       def format_display_name(date, type, fmt)
         date_int = date.strftime('%s').to_i
-        period = tz.period_for_local(date)
+        period = get_period_for_naming(date)
 
         flavor = if type == :generic
           :generic

--- a/lib/twitter_cldr/timezones/gmt_location.rb
+++ b/lib/twitter_cldr/timezones/gmt_location.rb
@@ -11,7 +11,7 @@ module TwitterCldr
       DEFAULT_GMT_ZERO_FORMAT = 'GMT'.freeze
 
       def display_name_for(date, format = DEFAULT_FORMAT)
-        offset = tz.period_for_local(date).offset
+        offset = get_period_for_naming(date).offset
         offset_secs = offset.utc_offset + offset.std_offset
         return gmt_zero_format if offset_secs == 0
 

--- a/lib/twitter_cldr/timezones/gmt_location.rb
+++ b/lib/twitter_cldr/timezones/gmt_location.rb
@@ -10,8 +10,8 @@ module TwitterCldr
       DEFAULT_FORMAT = :long_gmt
       DEFAULT_GMT_ZERO_FORMAT = 'GMT'.freeze
 
-      def display_name_for(date, format = DEFAULT_FORMAT)
-        offset = get_period_for_naming(date).offset
+      def display_name_for(date, format = DEFAULT_FORMAT, dst = TZInfo::Timezone.default_dst, &block)
+        offset = tz.period_for_local(date, dst, &block).offset
         offset_secs = offset.utc_offset + offset.std_offset
         return gmt_zero_format if offset_secs == 0
 

--- a/lib/twitter_cldr/timezones/iso8601_location.rb
+++ b/lib/twitter_cldr/timezones/iso8601_location.rb
@@ -28,7 +28,7 @@ module TwitterCldr
       ].freeze
 
       def display_name_for(date, fmt)
-        offset = tz.period_for_local(date).offset
+        offset = get_period_for_naming(date).offset
         offset_secs = offset.utc_offset + offset.std_offset
 
         case fmt

--- a/lib/twitter_cldr/timezones/iso8601_location.rb
+++ b/lib/twitter_cldr/timezones/iso8601_location.rb
@@ -27,8 +27,8 @@ module TwitterCldr
         :iso_extended_local_full
       ].freeze
 
-      def display_name_for(date, fmt)
-        offset = get_period_for_naming(date).offset
+      def display_name_for(date, fmt, dst = TZInfo::Timezone.default_dst, &block)
+        offset = tz.period_for_local(date, dst, &block).offset
         offset_secs = offset.utc_offset + offset.std_offset
 
         case fmt

--- a/lib/twitter_cldr/timezones/location.rb
+++ b/lib/twitter_cldr/timezones/location.rb
@@ -18,7 +18,11 @@ module TwitterCldr
       private
 
       def get_period_for_naming(date)
-        tz.period_for_local(date, &:first)
+        if date.utc?
+          tz.orig_tz.period_for_utc(date)
+        else
+          tz.period_for_local(date)
+        end
       end
     end
   end

--- a/lib/twitter_cldr/timezones/location.rb
+++ b/lib/twitter_cldr/timezones/location.rb
@@ -14,12 +14,6 @@ module TwitterCldr
       def resource
         @resource ||= TwitterCldr.get_locale_resource(tz.locale, :timezones)[tz.locale]
       end
-
-      private
-
-      def get_period_for_naming(date)
-        tz.orig_tz.period_for_utc(date.utc)
-      end
     end
   end
 end

--- a/lib/twitter_cldr/timezones/location.rb
+++ b/lib/twitter_cldr/timezones/location.rb
@@ -18,11 +18,7 @@ module TwitterCldr
       private
 
       def get_period_for_naming(date)
-        if date.utc?
-          tz.orig_tz.period_for_utc(date)
-        else
-          tz.period_for_local(date)
-        end
+        tz.orig_tz.period_for_utc(date.utc)
       end
     end
   end

--- a/lib/twitter_cldr/timezones/location.rb
+++ b/lib/twitter_cldr/timezones/location.rb
@@ -14,6 +14,12 @@ module TwitterCldr
       def resource
         @resource ||= TwitterCldr.get_locale_resource(tz.locale, :timezones)[tz.locale]
       end
+
+      private
+
+      def get_period_for_naming(date)
+        tz.period_for_local(date, &:first)
+      end
     end
   end
 end

--- a/lib/twitter_cldr/timezones/timezone.rb
+++ b/lib/twitter_cldr/timezones/timezone.rb
@@ -76,7 +76,7 @@ module TwitterCldr
       end
 
       def period_for_local(date)
-        tz.period_for_local(date)
+        tz.period_for_local(date, &:first)
       end
 
       def transitions_up_to(date)

--- a/lib/twitter_cldr/timezones/timezone.rb
+++ b/lib/twitter_cldr/timezones/timezone.rb
@@ -47,17 +47,17 @@ module TwitterCldr
         @locale = locale
       end
 
-      def display_name_for(date, format = :generic_location)
+      def display_name_for(date, format = :generic_location, dst = TZInfo::Timezone.default_dst, &block)
         case format
           when *GenericLocation::FORMATS
-            generic_location.display_name_for(date, format) ||
-              gmt_location.display_name_for(date, GENERIC_TO_GMT_MAP[format])
+            generic_location.display_name_for(date, format, dst, &block) ||
+              gmt_location.display_name_for(date, GENERIC_TO_GMT_MAP[format], dst, &block)
 
           when *GmtLocation::FORMATS
-            gmt_location.display_name_for(date, format)
+            gmt_location.display_name_for(date, format, dst, &block)
 
           when *Iso8601Location::FORMATS
-            iso_location.display_name_for(date, format)
+            iso_location.display_name_for(date, format, dst, &block)
 
           when :zone_id
             identifier
@@ -77,6 +77,10 @@ module TwitterCldr
 
       def period_for_local(*args, &block)
         tz.period_for_local(*args, &block)
+      end
+
+      def period_for_utc(time)
+        tz.period_for_utc(time)
       end
 
       def transitions_up_to(date)

--- a/lib/twitter_cldr/timezones/timezone.rb
+++ b/lib/twitter_cldr/timezones/timezone.rb
@@ -75,8 +75,8 @@ module TwitterCldr
         tz.identifier
       end
 
-      def period_for_local(date)
-        tz.period_for_local(date, &:first)
+      def period_for_local(*args, &block)
+        tz.period_for_local(*args, &block)
       end
 
       def transitions_up_to(date)

--- a/spec/timezones/timezone_spec.rb
+++ b/spec/timezones/timezone_spec.rb
@@ -266,4 +266,14 @@ describe 'Timezones' do
       end
     end
   end
+
+  describe '#period_for_local' do
+    it 'handles an ambiguous time' do
+      tz = TwitterCldr::Timezones::Timezone.instance('America/New_York', :en)
+      # Known ambiguous time
+      date = Time.parse('2021-11-07 01:01:23 UTC')
+
+      expect { tz.period_for_local(date) }.to_not raise_error
+    end
+  end
 end

--- a/spec/timezones/timezone_spec.rb
+++ b/spec/timezones/timezone_spec.rb
@@ -268,12 +268,12 @@ describe 'Timezones' do
   end
 
   describe '#period_for_local' do
-    it 'handles an ambiguous time' do
+    it 'accepts a block to handle an ambiguous time' do
       tz = TwitterCldr::Timezones::Timezone.instance('America/New_York', :en)
       # Known ambiguous time
       date = Time.parse('2021-11-07 01:01:23 UTC')
 
-      expect { tz.period_for_local(date) }.to_not raise_error
+      expect { tz.period_for_local(date, &:first) }.to_not raise_error
     end
   end
 end

--- a/spec/timezones/timezone_spec.rb
+++ b/spec/timezones/timezone_spec.rb
@@ -268,12 +268,33 @@ describe 'Timezones' do
   end
 
   describe '#period_for_local' do
-    it 'accepts a block to handle an ambiguous time' do
+    it 'accepts a block' do
       tz = TwitterCldr::Timezones::Timezone.instance('America/New_York', :en)
       # Known ambiguous time
       date = Time.parse('2021-11-07 01:01:23 UTC')
 
       expect { tz.period_for_local(date, &:first) }.to_not raise_error
+    end
+
+    it 'accepts a dst argument', :aggregate_failures do
+      tz = TwitterCldr::Timezones::Timezone.instance('America/New_York', :en)
+      # Known ambiguous time
+      date = Time.parse('2021-11-07 01:01:23 UTC')
+
+      expect(tz.period_for_local(date, false).dst?).to be false
+      expect(tz.period_for_local(date, true).dst?).to be true
+    end
+  end
+
+  describe 'handling ambiguous times with display_name_for' do
+    it 'correctly handles ambiguous UTC time', :aggregate_failures do
+      tz = TwitterCldr::Timezones::Timezone.instance('America/New_York', :en)
+      # Known ambiguous times
+      dst_date = Time.parse('2021-11-07 01:01:23 UTC')
+      non_dst_date = Time.parse('2021-11-07 12:01:23 UTC')
+
+      expect(tz.display_name_for(dst_date, :specific_long)).to eq 'Eastern Daylight Time'
+      expect(tz.display_name_for(non_dst_date, :specific_long)).to eq 'Eastern Standard Time'
     end
   end
 end

--- a/spec/timezones/timezone_spec.rb
+++ b/spec/timezones/timezone_spec.rb
@@ -287,12 +287,14 @@ describe 'Timezones' do
   end
 
   describe 'handling ambiguous times with display_name_for' do
-    it 'correctly handles ambiguous UTC time', :aggregate_failures do
+    it 'correctly handles ambiguous times', :aggregate_failures do
       tz = TwitterCldr::Timezones::Timezone.instance('America/New_York', :en)
       # Known ambiguous times
+      date = Time.parse('2021-11-07 01:01:23 -0400')
       dst_date = Time.parse('2021-11-07 01:01:23 UTC')
       non_dst_date = Time.parse('2021-11-07 12:01:23 UTC')
 
+      expect(tz.display_name_for(date, :specific_long)).to eq 'Eastern Daylight Time'
       expect(tz.display_name_for(dst_date, :specific_long)).to eq 'Eastern Daylight Time'
       expect(tz.display_name_for(non_dst_date, :specific_long)).to eq 'Eastern Standard Time'
     end


### PR DESCRIPTION
We ran into an odd issue where passing certain UTC times to `display_name_for` would raise an `TZInfo::AmbiguousTime` exception. A little digging lead me to to [this issue in the `tzinfo` repo](https://github.com/tzinfo/tzinfo/issues/32). This PR addresses this issue by passing a "fallback" block to `period_for_local`.

I wasn't sure the preferred way to add tests so I added a simple "demo" one.  I'm happy to update/add more if desired.