### PR TITLE
Replace BigDecimal.new() with BigDecimal() for ruby 2.7+ compatibility

### DIFF
--- a/lib/twitter_cldr/formatters/numbers/rbnf/rule_set.rb
+++ b/lib/twitter_cldr/formatters/numbers/rbnf/rule_set.rb
@@ -99,7 +99,7 @@ module TwitterCldr
             # the base value divided by the LCD.  Here we check to
             # see if that's an integer, and if not, how close it is
             # to being an integer.
-            temp_difference = numerator * BigDecimal.new(rules[i].base_value) % least_common_multiple
+            temp_difference = numerator * BigDecimal(rules[i].base_value) % least_common_multiple
 
             # normalize the result of the above calculation: we want
             # the numerator's distance from the CLOSEST multiple


### PR DESCRIPTION
BigDecimal.new was deprecated and then removed in ruby 2.7+

This replaces `BigDecimal.new()` with `BigDecimal()`

Closes #250 

