### PR TITLE
Adds github repo as homepage

### DIFF
--- a/twitter_cldr.gemspec
+++ b/twitter_cldr.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version  = ::TwitterCldr::VERSION
   s.authors  = ["Cameron Dutro"]
   s.email    = ["cdutro@twitter.com"]
-  s.homepage = "https://twitter.com"
+  s.homepage = "https://github.com/twitter/twitter-cldr-rb"
   s.license  = "Apache-2.0"
 
   s.description = s.summary = "Ruby implementation of the ICU (International Components for Unicode) that uses the Common Locale Data Repository to format dates, plurals, and more."


### PR DESCRIPTION
Hello!

Would be great if we could add the Github-repo to the gemspec.

Does this look okay? It is what I have used on other gems.
It will help e.g. Dependabot to include changelog in PRs.
