### PR TITLE
Fix bug in the CJK break engine causing an int to be compared to nil

### DIFF
--- a/lib/twitter_cldr/segmentation/cj_break_engine.rb
+++ b/lib/twitter_cldr/segmentation/cj_break_engine.rb
@@ -96,10 +96,10 @@ module TwitterCldr
           is_katakana = is_katakana?(cursor.codepoint)
 
           if !is_prev_katakana && is_katakana
-            j = cursor.position + 1
+            j = idx + 1
             cursor.advance
 
-            while j < end_pos && (j - idx) < MAX_KATAKANA_GROUP_LENGTH && is_katakana?(cursor.codepoint)
+            while cursor.position < end_pos && (j - idx) < MAX_KATAKANA_GROUP_LENGTH && is_katakana?(cursor.codepoint)
               cursor.advance
               j += 1
             end

--- a/lib/twitter_cldr/segmentation/cursor.rb
+++ b/lib/twitter_cldr/segmentation/cursor.rb
@@ -16,7 +16,11 @@ module TwitterCldr
       end
 
       def advance(amount = 1)
-        @position += amount
+        if @position + amount > text.size
+          @position = text.size
+        else
+          @position += amount
+        end
       end
 
       def reset


### PR DESCRIPTION
I'm really surprised our tests didn't catch this. The code effectively reads past the end of an array because it uses the wrong counter variable as an index 🤦 

Fixes #260