### PR TITLE
doc with yard: examples

### DIFF
--- a/lib/twitter_cldr/shared/properties_database.rb
+++ b/lib/twitter_cldr/shared/properties_database.rb
@@ -59,6 +59,11 @@ module TwitterCldr
           PropertySet.new(lookup_code_point(code_point))
       end
 
+      # List of property names
+      # @return [Array<String>] Array of property names string
+      # @example
+      #   TwitterCldr::Shared::CodePoint.properties.property_names
+      #   # => ["ASCII_Hex_Digit", "Age", "Alphabetic", … ]
       def property_names
         glob = File.join(root_path, '*')
         @property_names ||= Dir.glob(glob).map do |path|
@@ -66,6 +71,13 @@ module TwitterCldr
         end
       end
 
+      # Return possible values for a given property
+      # @param property_name [String] Property name
+      # @return [Array<String>|nil] List of values Values
+      # @example
+      #   TwitterCldr::Shared::CodePoint.properties.property_values_for('Script')
+      #   # => ["Adlam", "Ahom", "Anatolian_Hieroglyphs", … ]
+      # TwitterCldr::Shared::CodePoint.properties.property_values_for('Alphabetic') # => nil
       def property_values_for(property_name)
         if property_values.include?(property_name)
           return property_values[property_name]

--- a/lib/twitter_cldr/shared/property_set.rb
+++ b/lib/twitter_cldr/shared/property_set.rb
@@ -7,6 +7,7 @@ require 'forwardable'
 
 module TwitterCldr
   module Shared
+    # @note Properties are mostly accessed through the {TwitterCldr::Shared::CodePoint} class. {TwitterCldr::Shared::PropertySet} is used internally.
     class PropertySet
       include TwitterCldr::Shared::Properties
       extend SingleForwardable
@@ -19,10 +20,20 @@ module TwitterCldr
         @properties_hash = properties_hash
       end
 
+      # @example
+      #   properties = TwitterCldr::Shared::CodePoint.get(12367).properties
+      #   properties.age # => #<Set: {"1.1"}>
       def age
         properties_hash.fetch('Age', ['Unassigned'])
       end
 
+      # @example
+      #   # ZERO WIDTH JOINER
+      #   properties = TwitterCldr::Shared::CodePoint.get(0x200D).properties
+      #   properties.joining_type # => #<Set: {"Join_Causing"}>
+      #   # SPACE
+      #   properties = TwitterCldr::Shared::CodePoint.get(32).properties
+      #   properties.joining_type # => ["Non_Joining", "Non_Joining"]
       def joining_type
         properties_hash['Joining_Type'] ||= if general_category.empty?
           [ArabicShaping.joining_type_for_general_category('xx')]
@@ -39,6 +50,9 @@ module TwitterCldr
         ]
       end
 
+      # @example
+      #   properties = TwitterCldr::Shared::CodePoint.get(0x200D).properties
+      #   properties.block # => #<Set: {"General Punctuation"}>
       def block
         properties_hash['Block'] ||= ['No_Block']
       end


### PR DESCRIPTION
As there is no documentation outside the README, I wanted to start introducing library documentation with [yard](https://rubydoc.info/gems/yard/file/README.md).
I showcased a few simple examples in this PR.

Yard is automatically used for https://www.rubydoc.info/.

Here is an example for what it can looks like on one of my projects:

https://rubydoc.info/gems/unisec/Unisec%2FSurrogates%2Ehigh_surrogate

![image](https://github.com/twitter/twitter-cldr-rb/assets/16578570/b546a792-ed69-4326-9fa7-ddbb6fcb841e)

https://rubydoc.info/gems/unisec/Unisec%2FSurrogates:initialize

![image](https://github.com/twitter/twitter-cldr-rb/assets/16578570/c017f345-1dc4-4d30-891f-bcf5c8ec346a)

For example here on `property_values_for`, `@return [Array<String>|nil]` indicates it can either return an Array of string or `nil`. It's nice to be able to read it from the doc rather than having to read all the source code to figures it out. Indeed, one could expect that when a property don't have values it returns an empty Array and not nil. Not all the code is explicit so it may be nice to explain it at least for complex methods or one with not trivial behavior.

Let me know what you think, if the style is ok, should I continue to PR some doc, etc?