### PR TITLE
Exclude spec/ Folder from Gem Package to Reduce Size

### DIFF
--- a/twitter_cldr.gemspec
+++ b/twitter_cldr.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  gem_files       = Dir['{lib,spec,resources}/**/*', 'Gemfile', 'History.txt', 'LICENSE', 'NOTICE', 'README.md',
+  gem_files       = Dir['{lib,resources}/**/*', 'Gemfile', 'History.txt', 'LICENSE', 'NOTICE', 'README.md',
                         'Rakefile', 'twitter_cldr.gemspec']
-  excluded_files  = %w[spec/collation/CollationTest_CLDR_NON_IGNORABLE.txt spec/normalization/NormalizationTest.txt]
+  excluded_files  = %w[]
   versioned_files = `git ls-files`.split("\n")
 
   s.files = (gem_files - excluded_files) & versioned_files


### PR DESCRIPTION
I've removed the spec/ folder from the gem package to reduce its size, as it's over 30MB due to large test files. This folder, is only for testing and doesn't need to be in the packaged gem. This change lowers the package size, improving installation speed without affecting functionality.