### PR TITLE
Fix sentence segmentation bug

### DIFF
--- a/lib/twitter_cldr/segmentation/rule_set.rb
+++ b/lib/twitter_cldr/segmentation/rule_set.rb
@@ -31,7 +31,7 @@ module TwitterCldr
 
         until cursor.position >= stop || cursor.eos?
           state_machine.handle_next(cursor)
-          yield cursor.position if suppressions.should_break?(cursor)
+          yield cursor.position if cursor.eos? || suppressions.should_break?(cursor)
         end
       end
 

--- a/spec/segmentation/break_iterator_spec.rb
+++ b/spec/segmentation/break_iterator_spec.rb
@@ -52,6 +52,13 @@ describe TwitterCldr::Segmentation::BreakIterator do
           "She's nice."
         ])
       end
+
+      it "splits correctly when a string ends with an exception directly followed by a single space" do
+        str = "I like the Mrs. "
+        expect(iterator.each_sentence(str).map { |word, _, _| word }).to eq([
+          "I like the Mrs. "
+        ])
+      end
     end
 
     context "without ULI exceptions" do


### PR DESCRIPTION
Using this gem's sentence segmentation feature, we recently uncovered a bug.

With ULI rules enabled, when trying to segment into sentences a string that ends with an exception (e.g. the abbreviation "Mrs.") directly followed by a single space, we found that the segmentation returns an array in which the last sentence is missing.

```ruby
iterator = TwitterCldr::Segmentation::BreakIterator.new(:en, :use_uli_exceptions => true)
iterator.each_sentence("I like the Mrs. ").to_a # []
```

We have written the simplest possible spec for this in `spec/segmentation/break_iterator_spec.rb`:
```ruby
it "splits correctly when a string ends with an exception directly followed by a single space" do
  str = "I like the Mrs. "
  expect(iterator.each_sentence(str).map { |word, _, _| word }).to eq([
    "I like the Mrs. "
  ])
end
```

This spec was failing, but now it works with our fix. Indeed, sentence segmentation now returns all sentences, including the last sentence that ends with an exception directly followed by a single space.

All other tests still pass.

Thank you for considering this PR. At the same time, we are submitting a [PR](https://github.com/camertron/cldr-segmentation.js/pull/18) on https://github.com/camertron/cldr-segmentation.js, which is a JS-port of this segmentation tool and has the same identical bug.