### PR TITLE
add bigdecimal as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,7 @@ group :test do
   gem 'launchy'
   gem 'addressable', '~> 2.4'
 end
+
+group :runtime do
+  gem 'bigdecimal', '~> 3.1', '>= 3.1.9'
+end


### PR DESCRIPTION
bigdecimal is no longer part of the standard library since ruby 3.4

so this fix deprecation warning when running twitter-cldr on previous ruby versions and fix LoadError on ruby 3.4.

ref. https://docs.ruby-lang.org/en/3.4/NEWS_md.html

![image](https://github.com/user-attachments/assets/12cbebf5-f6f8-46c1-8cda-2eb5e37ebf5a)

