### PR TITLE
Allow for passing options into `LocalizedDateTime#to_*_s`

### DIFF
--- a/lib/twitter_cldr/formatters/calendars/date_time_formatter.rb
+++ b/lib/twitter_cldr/formatters/calendars/date_time_formatter.rb
@@ -289,8 +289,10 @@ module TwitterCldr
         tz = TwitterCldr::Timezones::Timezone.instance(
           options[:timezone] || 'UTC', data_reader.locale
         )
+        fmt = TZ_PATTERNS[pattern]
 
-        tz.display_name_for(time, TZ_PATTERNS[pattern])
+        args = [time, fmt, options[:dst]].compact
+        tz.display_name_for(*args)
       end
 
       # ported from icu4j 64.2

--- a/lib/twitter_cldr/localized/localized_datetime.rb
+++ b/lib/twitter_cldr/localized/localized_datetime.rb
@@ -24,11 +24,11 @@ module TwitterCldr
       end
 
       types.each do |type|
-        define_method "to_#{type}_s" do
+        define_method "to_#{type}_s" do |options = {}|
           # @ TODO: these need to be cheap to create
           data_reader = data_reader_for(type)
           tokens = data_reader.tokenizer.tokenize(data_reader.pattern)
-          data_reader.formatter.format(tokens, base_in_timezone, chain_params)
+          data_reader.formatter.format(tokens, base_in_timezone, chain_params.merge(options))
         end
       end
 

--- a/spec/localized/localized_time_spec.rb
+++ b/spec/localized/localized_time_spec.rb
@@ -7,6 +7,7 @@ require 'spec_helper'
 
 describe TwitterCldr::Localized::LocalizedTime do
   let(:time) { Time.now }
+  let(:dst_ambiguous_time) { Time.parse("2024-10-27T00:00Z").localize(:en).with_timezone("Europe/Warsaw") }
 
   describe "stringify" do
     it "should stringify with a default calendar" do
@@ -14,6 +15,18 @@ describe TwitterCldr::Localized::LocalizedTime do
       time.localize(:th).to_long_s
       time.localize(:th).to_medium_s
       time.localize(:th).to_short_s
+    end
+
+    it 'should allow for setting the dst flag' do
+      expect { dst_ambiguous_time.to_full_s(dst: nil) }.to(
+        raise_error(TZInfo::AmbiguousTime, '2024-10-27 02:00:00 UTC is an ambiguous local time.')
+      )
+      expect(dst_ambiguous_time.to_full_s(dst: true)).to(
+        eq('2:00:00 AM Central European Summer Time')
+      )
+      expect(dst_ambiguous_time.to_full_s(dst: false)).to(
+        eq('2:00:00 AM Central European Standard Time')
+      )
     end
   end
 


### PR DESCRIPTION
👋 Hello again @camertron. It's Michael from `ruby-cldr` (and now Stripe). It's good to see you again. 👋  

### What are you trying to accomplish?

Allow for passing in `dst` parameter into `LocalizedDateTime#to_long_s`

Fixes #279.

### What approach did you choose and why?

I changed `LocalizedDateTime#to_*_s` to accept an options hash.
Then I changed `DateTimeFormatter#timezone` to pick out the `dst` param and pass it through to `Timezone#display_name_for`

### What should reviewers focus on?

All of the existing formatter methods already take in an `options` hash. However, `timezone` was the only one that was actually doing anything with it.

### The impact of these changes

You will be able to request the formatting of DST-ambiguous times using the stringify functions.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

🤷 Tests pass.