### PR TITLE
README fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,7 +1073,7 @@ TwitterCldr.locale    # will return :ru
 
 ## Compatibility
 
-TwitterCLDR is fully compatible with Ruby 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2.
+TwitterCLDR is fully compatible with Ruby 2.5, 2.6, 2.7, 3.0, 3.1, 3.2.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1097,10 +1097,10 @@ TwitterCLDR currently supports localization of certain textual objects in JavaSc
 
 * Cameron C. Dutro: http://github.com/camertron
 * Kirill Lashuk: http://github.com/kl-7
-* Portions adapted from the ruby-cldr gem by Sven Fuchs: http://github.com/svenfuchs/ruby-cldr
+* Portions adapted from the ruby-cldr gem by Sven Fuchs: https://github.com/ruby-i18n/ruby-cldr
 
 ## Links
-* ruby-cldr gem: [http://github.com/svenfuchs/ruby-cldr](http://github.com/svenfuchs/ruby-cldr)
+* ruby-cldr gem: [https://github.com/ruby-i18n/ruby-cldr](https://github.com/ruby-i18n/ruby-cldr)
 * fast_gettext gem: [https://github.com/grosser/fast_gettext](https://github.com/grosser/fast_gettext)
 * CLDR homepage: [http://cldr.unicode.org/](http://cldr.unicode.org/)
 

--- a/README.md.erb
+++ b/README.md.erb
@@ -1056,10 +1056,10 @@ TwitterCLDR currently supports localization of certain textual objects in JavaSc
 
 * Cameron C. Dutro: http://github.com/camertron
 * Kirill Lashuk: http://github.com/kl-7
-* Portions adapted from the ruby-cldr gem by Sven Fuchs: http://github.com/svenfuchs/ruby-cldr
+* Portions adapted from the ruby-cldr gem by Sven Fuchs: https://github.com/ruby-i18n/ruby-cldr
 
 ## Links
-* ruby-cldr gem: [http://github.com/svenfuchs/ruby-cldr](http://github.com/svenfuchs/ruby-cldr)
+* ruby-cldr gem: [https://github.com/ruby-i18n/ruby-cldr](https://github.com/ruby-i18n/ruby-cldr)
 * fast_gettext gem: [https://github.com/grosser/fast_gettext](https://github.com/grosser/fast_gettext)
 * CLDR homepage: [http://cldr.unicode.org/](http://cldr.unicode.org/)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Just fixing up some typos that I noticed while working on #280 

### What approach did you choose and why?

* Replaced references to the old URL for `ruby-cldr`
* Dropped references to Ruby 2.3 and 2.4 (removed in https://github.com/twitter/twitter-cldr-rb/commit/b5e206e3de01e7541446322b2116df4e6de83345) 

### What should reviewers focus on?

🤷 

### The impact of these changes

🤷 Slightly cleaner README.

### Testing

The URLs still work.