### PR TITLE
Locale display patterns importer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -239,6 +239,11 @@ namespace :update do
     TwitterCldr::Resources::HyphenationImporter.new.import
   end
 
+  desc 'Import locale display patterns'
+  task :locale_display_patterns do
+    TwitterCldr::Resources::LocaleDisplayPatternImporter.new.import
+  end
+
   desc 'Update README'
   task :readme do |_, args|
     renderer = TwitterCldr::Resources::ReadmeRenderer.new(

--- a/lib/twitter_cldr/resources.rb
+++ b/lib/twitter_cldr/resources.rb
@@ -24,6 +24,7 @@ module TwitterCldr
     autoload :LanguageCodesImporter,          'twitter_cldr/resources/language_codes_importer'
     autoload :ListFormatsImporter,            'twitter_cldr/resources/list_formats_importer'
     autoload :Loader,                         'twitter_cldr/resources/loader'
+    autoload :LocaleDisplayPatternImporter,   'twitter_cldr/resources/locale_display_pattern_importer'
     autoload :LocalesResourcesImporter,       'twitter_cldr/resources/locales_resources_importer'
     autoload :NumberFormatsImporter,          'twitter_cldr/resources/number_formats_importer'
     autoload :ParentLocalesImporter,          'twitter_cldr/resources/parent_locales_importer'
@@ -70,6 +71,7 @@ module TwitterCldr
           HyphenationImporter,
           LanguageCodesImporter,
           ListFormatsImporter,
+          LocaleDisplayPatternImporter,
           LocalesResourcesImporter,
           NumberFormatsImporter,
           ParentLocalesImporter,

--- a/lib/twitter_cldr/resources/locale_display_pattern_importer.rb
+++ b/lib/twitter_cldr/resources/locale_display_pattern_importer.rb
@@ -57,9 +57,13 @@ module TwitterCldr
             %w[localePattern localeSeparator localeKeyTypePattern].each do |key|
               elem = node.xpath(key).first
               next unless elem
-              result[key.to_sym] = elem.content
+              result[underscore(key).to_sym] = elem.content
             end
           end
+        end
+
+        def underscore(str)
+          str.gsub(/(.)([A-Z])/, '\1_\2').downcase
         end
 
         def doc

--- a/lib/twitter_cldr/resources/locale_display_pattern_importer.rb
+++ b/lib/twitter_cldr/resources/locale_display_pattern_importer.rb
@@ -1,0 +1,76 @@
+# encoding: UTF-8
+
+require 'nokogiri'
+
+module TwitterCldr
+  module Resources
+    class LocaleDisplayPatternImporter < Importer
+      requirement :cldr, Versions.cldr_version
+      output_path 'locales'
+      locales TwitterCldr.supported_locales
+      ruby_engine :mri
+
+      private
+
+      def execute
+        params[:locales].each do |locale|
+          import_locale(locale)
+        end
+      end
+
+      def import_locale(locale)
+        data = requirements[:cldr].build_data(locale) do |ancestor_locale|
+          LocaleDisplayPattern.new(ancestor_locale, requirements[:cldr]).to_h
+        end
+
+        output_file = File.join(output_path, locale.to_s, 'locale_display_pattern.yml')
+        File.open(output_file, 'w:utf-8') do |output|
+          output.write(
+            TwitterCldr::Utils::YAML.dump(
+              TwitterCldr::Utils.deep_symbolize_keys(locale => data),
+              use_natural_symbols: true
+            )
+          )
+        end
+      end
+
+      def output_path
+        params.fetch(:output_path)
+      end
+
+      class LocaleDisplayPattern
+        attr_reader :locale, :cldr_req
+
+        def initialize(locale, cldr_req)
+          @locale = locale
+          @cldr_req = cldr_req
+        end
+
+        def to_h
+          { locale_display_pattern: locale_display_pattern }
+        end
+
+        private
+
+        def locale_display_pattern
+          doc.xpath('//ldml/localeDisplayNames/localeDisplayPattern').each_with_object({}) do |node, result|
+            result[:locale_pattern] = node.xpath('localePattern').text
+            result[:locale_separator] = node.xpath('localeSeparator').text
+            result[:locale_key_type_pattern] = node.xpath('localeKeyTypePattern').text
+          end
+        end
+
+        def doc
+          @doc ||= begin
+            locale_fs = locale.to_s.gsub('-', '_')
+            Nokogiri.XML(File.read(File.join(cldr_main_path, "#{locale_fs}.xml")))
+          end
+        end
+
+        def cldr_main_path
+          @cldr_main_path ||= File.join(cldr_req.common_path, 'main')
+        end
+      end
+    end
+  end
+end

--- a/lib/twitter_cldr/resources/locale_display_pattern_importer.rb
+++ b/lib/twitter_cldr/resources/locale_display_pattern_importer.rb
@@ -54,9 +54,11 @@ module TwitterCldr
 
         def locale_display_pattern
           doc.xpath('//ldml/localeDisplayNames/localeDisplayPattern').each_with_object({}) do |node, result|
-            result[:locale_pattern] = node.xpath('localePattern').text
-            result[:locale_separator] = node.xpath('localeSeparator').text
-            result[:locale_key_type_pattern] = node.xpath('localeKeyTypePattern').text
+            %w[localePattern localeSeparator localeKeyTypePattern].each do |key|
+              elem = node.xpath(key).first
+              next unless elem
+              result[key.to_sym] = elem.content
+            end
           end
         end
 

--- a/lib/twitter_cldr/shared.rb
+++ b/lib/twitter_cldr/shared.rb
@@ -17,6 +17,7 @@ module TwitterCldr
     autoload :Languages,              'twitter_cldr/shared/languages'
     autoload :LikelySubtags,          'twitter_cldr/shared/likely_subtags'
     autoload :Locale,                 'twitter_cldr/shared/locale'
+    autoload :LocaleDisplayName,      'twitter_cldr/shared/locale_display_name'
     autoload :NumberingSystem,        'twitter_cldr/shared/numbering_system'
     autoload :Numbers,                'twitter_cldr/shared/numbers'
     autoload :PhoneCodes,             'twitter_cldr/shared/phone_codes'

--- a/lib/twitter_cldr/shared/locale_display_name.rb
+++ b/lib/twitter_cldr/shared/locale_display_name.rb
@@ -1,0 +1,68 @@
+module TwitterCldr
+  module Shared
+    class LocaleDisplayName
+      attr_reader :locale, :dest_locale
+
+      class << self
+        def from_code(code)
+          from_code_for_locale(code, TwitterCldr.locale)
+        end
+
+        def from_code_for_locale(code, locale)
+          new(code, locale).display_name
+        end
+      end
+
+      def initialize(locale, dest_locale = TwitterCldr.locale)
+        @locale = locale
+        @dest_locale = dest_locale
+      end
+
+      # `display_name` implements the CLDR Locale Display Name algorithm as
+      # defined in the Unicode CLDR specification.
+      #
+      # @see https://www.unicode.org/reports/tr35/tr35-general.html#locale_display_name_algorithm
+      def display_name
+        input_locale = TwitterCldr::Shared::Locale.parse(locale)
+        base_code, lbn =
+          input_locale
+            .permutations('-')
+            .map { |code| [code, TwitterCldr::Shared::Languages.from_code_for_locale(code, dest_locale)] }
+            .find { |_, name| !name.nil? }
+        base_locale = TwitterCldr::Shared::Locale.parse(base_code)
+
+        lqs = []
+
+        if !base_locale.region && (input_region = input_locale.region)
+          lqs << TwitterCldr::Shared::Territories.from_territory_code_for_locale(input_region, dest_locale)
+        end
+
+        # We do not support scripts, variants, or t/u extensions at this time
+
+        return lbn if lqs.empty?
+
+        pattern = locale_pattern
+        pattern.gsub("{0}", lbn).gsub("{1}", lqs.join(locale_separator))
+      end
+
+      def locale_pattern
+        get_resource[:locale_display_pattern][:locale_pattern]
+      end
+
+      def locale_separator
+        get_resource[:locale_display_pattern][:locale_separator]
+      end
+
+      def locale_key_type_pattern
+        get_resource[:locale_display_pattern][:locale_key_type_pattern]
+      end
+
+      private
+
+      def get_resource
+        converted_locale = TwitterCldr.convert_locale(dest_locale)
+        TwitterCldr.get_locale_resource(converted_locale, :locale_display_pattern)[converted_locale]
+      end
+    end
+  end
+end

--- a/resources/locales/af/locale_display_pattern.yml
+++ b/resources/locales/af/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:af: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/af/locale_display_pattern.yml
+++ b/resources/locales/af/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :af: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ar/locale_display_pattern.yml
+++ b/resources/locales/ar/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ar: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}، {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}، {1}"

--- a/resources/locales/ar/locale_display_pattern.yml
+++ b/resources/locales/ar/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ar: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}، {1}"

--- a/resources/locales/az/locale_display_pattern.yml
+++ b/resources/locales/az/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:az: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/az/locale_display_pattern.yml
+++ b/resources/locales/az/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :az: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/be/locale_display_pattern.yml
+++ b/resources/locales/be/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :be: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/be/locale_display_pattern.yml
+++ b/resources/locales/be/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:be: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/bg/locale_display_pattern.yml
+++ b/resources/locales/bg/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:bg: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/bg/locale_display_pattern.yml
+++ b/resources/locales/bg/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :bg: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/bn/locale_display_pattern.yml
+++ b/resources/locales/bn/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:bn: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/bn/locale_display_pattern.yml
+++ b/resources/locales/bn/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :bn: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/bo/locale_display_pattern.yml
+++ b/resources/locales/bo/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:bo: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/bo/locale_display_pattern.yml
+++ b/resources/locales/bo/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :bo: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/bs/locale_display_pattern.yml
+++ b/resources/locales/bs/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:bs: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/bs/locale_display_pattern.yml
+++ b/resources/locales/bs/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :bs: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ca/locale_display_pattern.yml
+++ b/resources/locales/ca/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ca: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ca/locale_display_pattern.yml
+++ b/resources/locales/ca/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ca: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/cs/locale_display_pattern.yml
+++ b/resources/locales/cs/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :cs: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/cs/locale_display_pattern.yml
+++ b/resources/locales/cs/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:cs: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/cy/locale_display_pattern.yml
+++ b/resources/locales/cy/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :cy: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/cy/locale_display_pattern.yml
+++ b/resources/locales/cy/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:cy: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/da/locale_display_pattern.yml
+++ b/resources/locales/da/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:da: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/da/locale_display_pattern.yml
+++ b/resources/locales/da/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :da: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/de-AT/locale_display_pattern.yml
+++ b/resources/locales/de-AT/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :de-AT: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/de-AT/locale_display_pattern.yml
+++ b/resources/locales/de-AT/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:de-AT: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/de-CH/locale_display_pattern.yml
+++ b/resources/locales/de-CH/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :de-CH: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/de-CH/locale_display_pattern.yml
+++ b/resources/locales/de-CH/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:de-CH: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/de/locale_display_pattern.yml
+++ b/resources/locales/de/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :de: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/de/locale_display_pattern.yml
+++ b/resources/locales/de/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:de: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/el/locale_display_pattern.yml
+++ b/resources/locales/el/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :el: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/el/locale_display_pattern.yml
+++ b/resources/locales/el/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:el: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-001/locale_display_pattern.yml
+++ b/resources/locales/en-001/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-001: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-001/locale_display_pattern.yml
+++ b/resources/locales/en-001/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-001: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-150/locale_display_pattern.yml
+++ b/resources/locales/en-150/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-150: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-150/locale_display_pattern.yml
+++ b/resources/locales/en-150/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-150: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-AU/locale_display_pattern.yml
+++ b/resources/locales/en-AU/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-AU: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-AU/locale_display_pattern.yml
+++ b/resources/locales/en-AU/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-AU: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-CA/locale_display_pattern.yml
+++ b/resources/locales/en-CA/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-CA: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-CA/locale_display_pattern.yml
+++ b/resources/locales/en-CA/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-CA: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-GB/locale_display_pattern.yml
+++ b/resources/locales/en-GB/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-GB: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-GB/locale_display_pattern.yml
+++ b/resources/locales/en-GB/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-GB: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-IE/locale_display_pattern.yml
+++ b/resources/locales/en-IE/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-IE: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-IE/locale_display_pattern.yml
+++ b/resources/locales/en-IE/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-IE: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-IN/locale_display_pattern.yml
+++ b/resources/locales/en-IN/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-IN: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-IN/locale_display_pattern.yml
+++ b/resources/locales/en-IN/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-IN: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-NZ/locale_display_pattern.yml
+++ b/resources/locales/en-NZ/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-NZ: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-NZ/locale_display_pattern.yml
+++ b/resources/locales/en-NZ/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-NZ: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-SG/locale_display_pattern.yml
+++ b/resources/locales/en-SG/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-SG: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-SG/locale_display_pattern.yml
+++ b/resources/locales/en-SG/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-SG: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-US/locale_display_pattern.yml
+++ b/resources/locales/en-US/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-US: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-US/locale_display_pattern.yml
+++ b/resources/locales/en-US/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-US: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en-ZA/locale_display_pattern.yml
+++ b/resources/locales/en-ZA/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en-ZA: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/en-ZA/locale_display_pattern.yml
+++ b/resources/locales/en-ZA/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en-ZA: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en/locale_display_pattern.yml
+++ b/resources/locales/en/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :en: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/en/locale_display_pattern.yml
+++ b/resources/locales/en/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:en: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/eo/locale_display_pattern.yml
+++ b/resources/locales/eo/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:eo: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/eo/locale_display_pattern.yml
+++ b/resources/locales/eo/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :eo: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/es-419/locale_display_pattern.yml
+++ b/resources/locales/es-419/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :es-419: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/es-419/locale_display_pattern.yml
+++ b/resources/locales/es-419/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:es-419: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/es-AR/locale_display_pattern.yml
+++ b/resources/locales/es-AR/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:es-AR: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/es-AR/locale_display_pattern.yml
+++ b/resources/locales/es-AR/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :es-AR: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/es-CO/locale_display_pattern.yml
+++ b/resources/locales/es-CO/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:es-CO: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/es-CO/locale_display_pattern.yml
+++ b/resources/locales/es-CO/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :es-CO: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/es-MX/locale_display_pattern.yml
+++ b/resources/locales/es-MX/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :es-MX: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/es-MX/locale_display_pattern.yml
+++ b/resources/locales/es-MX/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:es-MX: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/es-US/locale_display_pattern.yml
+++ b/resources/locales/es-US/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:es-US: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/es-US/locale_display_pattern.yml
+++ b/resources/locales/es-US/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :es-US: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/es/locale_display_pattern.yml
+++ b/resources/locales/es/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:es: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/es/locale_display_pattern.yml
+++ b/resources/locales/es/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :es: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/et/locale_display_pattern.yml
+++ b/resources/locales/et/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :et: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/et/locale_display_pattern.yml
+++ b/resources/locales/et/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:et: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/eu/locale_display_pattern.yml
+++ b/resources/locales/eu/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :eu: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/eu/locale_display_pattern.yml
+++ b/resources/locales/eu/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:eu: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/fa/locale_display_pattern.yml
+++ b/resources/locales/fa/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:fa: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}، {1}"

--- a/resources/locales/fa/locale_display_pattern.yml
+++ b/resources/locales/fa/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :fa: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}، {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}، {1}"

--- a/resources/locales/fi/locale_display_pattern.yml
+++ b/resources/locales/fi/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :fi: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/fi/locale_display_pattern.yml
+++ b/resources/locales/fi/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:fi: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/fil/locale_display_pattern.yml
+++ b/resources/locales/fil/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :fil: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/fil/locale_display_pattern.yml
+++ b/resources/locales/fil/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:fil: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/fr-BE/locale_display_pattern.yml
+++ b/resources/locales/fr-BE/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:fr-BE: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0} : {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/fr-BE/locale_display_pattern.yml
+++ b/resources/locales/fr-BE/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :fr-BE: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0} : {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0} : {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/fr-CA/locale_display_pattern.yml
+++ b/resources/locales/fr-CA/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :fr-CA: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0} : {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0} : {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/fr-CA/locale_display_pattern.yml
+++ b/resources/locales/fr-CA/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:fr-CA: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0} : {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/fr-CH/locale_display_pattern.yml
+++ b/resources/locales/fr-CH/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :fr-CH: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0} : {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0} : {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/fr-CH/locale_display_pattern.yml
+++ b/resources/locales/fr-CH/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:fr-CH: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0} : {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/fr/locale_display_pattern.yml
+++ b/resources/locales/fr/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:fr: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0} : {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/fr/locale_display_pattern.yml
+++ b/resources/locales/fr/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :fr: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0} : {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0} : {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ga/locale_display_pattern.yml
+++ b/resources/locales/ga/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ga: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ga/locale_display_pattern.yml
+++ b/resources/locales/ga/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ga: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/gl/locale_display_pattern.yml
+++ b/resources/locales/gl/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:gl: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/gl/locale_display_pattern.yml
+++ b/resources/locales/gl/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :gl: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/gu/locale_display_pattern.yml
+++ b/resources/locales/gu/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:gu: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/gu/locale_display_pattern.yml
+++ b/resources/locales/gu/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :gu: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/he/locale_display_pattern.yml
+++ b/resources/locales/he/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :he: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}:‏ {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}:‏ {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/he/locale_display_pattern.yml
+++ b/resources/locales/he/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:he: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}:‏ {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/hi/locale_display_pattern.yml
+++ b/resources/locales/hi/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :hi: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/hi/locale_display_pattern.yml
+++ b/resources/locales/hi/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:hi: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/hr/locale_display_pattern.yml
+++ b/resources/locales/hr/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:hr: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/hr/locale_display_pattern.yml
+++ b/resources/locales/hr/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :hr: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/hu/locale_display_pattern.yml
+++ b/resources/locales/hu/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:hu: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/hu/locale_display_pattern.yml
+++ b/resources/locales/hu/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :hu: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/hy/locale_display_pattern.yml
+++ b/resources/locales/hy/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:hy: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}՝ {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/hy/locale_display_pattern.yml
+++ b/resources/locales/hy/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :hy: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}՝ {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}՝ {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/id/locale_display_pattern.yml
+++ b/resources/locales/id/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :id: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/id/locale_display_pattern.yml
+++ b/resources/locales/id/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:id: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/is/locale_display_pattern.yml
+++ b/resources/locales/is/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :is: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/is/locale_display_pattern.yml
+++ b/resources/locales/is/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:is: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/it-CH/locale_display_pattern.yml
+++ b/resources/locales/it-CH/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :it-CH: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/it-CH/locale_display_pattern.yml
+++ b/resources/locales/it-CH/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:it-CH: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/it/locale_display_pattern.yml
+++ b/resources/locales/it/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :it: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/it/locale_display_pattern.yml
+++ b/resources/locales/it/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:it: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ja/locale_display_pattern.yml
+++ b/resources/locales/ja/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ja: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}、{1}"

--- a/resources/locales/ja/locale_display_pattern.yml
+++ b/resources/locales/ja/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ja: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}、{1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}、{1}"

--- a/resources/locales/ka/locale_display_pattern.yml
+++ b/resources/locales/ka/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ka: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ka/locale_display_pattern.yml
+++ b/resources/locales/ka/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ka: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/kk/locale_display_pattern.yml
+++ b/resources/locales/kk/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:kk: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/kk/locale_display_pattern.yml
+++ b/resources/locales/kk/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :kk: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/km/locale_display_pattern.yml
+++ b/resources/locales/km/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :km: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}៖ {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}៖ {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/km/locale_display_pattern.yml
+++ b/resources/locales/km/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:km: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}៖ {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/kn/locale_display_pattern.yml
+++ b/resources/locales/kn/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:kn: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/kn/locale_display_pattern.yml
+++ b/resources/locales/kn/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :kn: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ko/locale_display_pattern.yml
+++ b/resources/locales/ko/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ko: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0}({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ko/locale_display_pattern.yml
+++ b/resources/locales/ko/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ko: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0}({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0}({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/lo/locale_display_pattern.yml
+++ b/resources/locales/lo/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :lo: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/lo/locale_display_pattern.yml
+++ b/resources/locales/lo/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:lo: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/lt/locale_display_pattern.yml
+++ b/resources/locales/lt/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:lt: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/lt/locale_display_pattern.yml
+++ b/resources/locales/lt/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :lt: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/lv/locale_display_pattern.yml
+++ b/resources/locales/lv/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:lv: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/lv/locale_display_pattern.yml
+++ b/resources/locales/lv/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :lv: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/mk/locale_display_pattern.yml
+++ b/resources/locales/mk/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :mk: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/mk/locale_display_pattern.yml
+++ b/resources/locales/mk/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:mk: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/mr/locale_display_pattern.yml
+++ b/resources/locales/mr/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:mr: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/mr/locale_display_pattern.yml
+++ b/resources/locales/mr/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :mr: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ms/locale_display_pattern.yml
+++ b/resources/locales/ms/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ms: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ms/locale_display_pattern.yml
+++ b/resources/locales/ms/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ms: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/mt/locale_display_pattern.yml
+++ b/resources/locales/mt/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :mt: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/mt/locale_display_pattern.yml
+++ b/resources/locales/mt/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:mt: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/my/locale_display_pattern.yml
+++ b/resources/locales/my/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:my: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}- {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}/ {1}"

--- a/resources/locales/my/locale_display_pattern.yml
+++ b/resources/locales/my/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :my: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}- {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}/ {1}"
+    :locale_key_type_pattern: "{0}- {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}/ {1}"

--- a/resources/locales/nb/locale_display_pattern.yml
+++ b/resources/locales/nb/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:nb: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/nb/locale_display_pattern.yml
+++ b/resources/locales/nb/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :nb: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/nl-BE/locale_display_pattern.yml
+++ b/resources/locales/nl-BE/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :nl-BE: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/nl-BE/locale_display_pattern.yml
+++ b/resources/locales/nl-BE/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:nl-BE: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/nl/locale_display_pattern.yml
+++ b/resources/locales/nl/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :nl: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/nl/locale_display_pattern.yml
+++ b/resources/locales/nl/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:nl: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/pl/locale_display_pattern.yml
+++ b/resources/locales/pl/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:pl: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/pl/locale_display_pattern.yml
+++ b/resources/locales/pl/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :pl: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/pt-PT/locale_display_pattern.yml
+++ b/resources/locales/pt-PT/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:pt-PT: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/pt-PT/locale_display_pattern.yml
+++ b/resources/locales/pt-PT/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :pt-PT: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/pt/locale_display_pattern.yml
+++ b/resources/locales/pt/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :pt: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/pt/locale_display_pattern.yml
+++ b/resources/locales/pt/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:pt: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ro/locale_display_pattern.yml
+++ b/resources/locales/ro/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ro: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ro/locale_display_pattern.yml
+++ b/resources/locales/ro/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ro: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ru/locale_display_pattern.yml
+++ b/resources/locales/ru/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ru: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ru/locale_display_pattern.yml
+++ b/resources/locales/ru/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ru: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sk/locale_display_pattern.yml
+++ b/resources/locales/sk/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sk: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sk/locale_display_pattern.yml
+++ b/resources/locales/sk/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sk: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sl/locale_display_pattern.yml
+++ b/resources/locales/sl/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sl: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sl/locale_display_pattern.yml
+++ b/resources/locales/sl/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sl: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sq/locale_display_pattern.yml
+++ b/resources/locales/sq/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sq: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sq/locale_display_pattern.yml
+++ b/resources/locales/sq/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sq: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sr-Cyrl-ME/locale_display_pattern.yml
+++ b/resources/locales/sr-Cyrl-ME/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sr-Cyrl-ME: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sr-Cyrl-ME/locale_display_pattern.yml
+++ b/resources/locales/sr-Cyrl-ME/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sr-Cyrl-ME: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sr-Latn-ME/locale_display_pattern.yml
+++ b/resources/locales/sr-Latn-ME/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sr-Latn-ME: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sr-Latn-ME/locale_display_pattern.yml
+++ b/resources/locales/sr-Latn-ME/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sr-Latn-ME: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sr/locale_display_pattern.yml
+++ b/resources/locales/sr/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sr: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sr/locale_display_pattern.yml
+++ b/resources/locales/sr/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sr: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sv/locale_display_pattern.yml
+++ b/resources/locales/sv/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sv: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sv/locale_display_pattern.yml
+++ b/resources/locales/sv/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sv: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/sw/locale_display_pattern.yml
+++ b/resources/locales/sw/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:sw: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/sw/locale_display_pattern.yml
+++ b/resources/locales/sw/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :sw: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/ta/locale_display_pattern.yml
+++ b/resources/locales/ta/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ta: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ta/locale_display_pattern.yml
+++ b/resources/locales/ta/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ta: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/th/locale_display_pattern.yml
+++ b/resources/locales/th/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :th: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/th/locale_display_pattern.yml
+++ b/resources/locales/th/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:th: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/tr/locale_display_pattern.yml
+++ b/resources/locales/tr/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:tr: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/tr/locale_display_pattern.yml
+++ b/resources/locales/tr/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :tr: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/uk/locale_display_pattern.yml
+++ b/resources/locales/uk/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :uk: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/uk/locale_display_pattern.yml
+++ b/resources/locales/uk/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:uk: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/ur/locale_display_pattern.yml
+++ b/resources/locales/ur/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:ur: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}،{1}"

--- a/resources/locales/ur/locale_display_pattern.yml
+++ b/resources/locales/ur/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :ur: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}،{1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}،{1}"

--- a/resources/locales/vi/locale_display_pattern.yml
+++ b/resources/locales/vi/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :vi: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/vi/locale_display_pattern.yml
+++ b/resources/locales/vi/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:vi: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/xh/locale_display_pattern.yml
+++ b/resources/locales/xh/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:xh: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/xh/locale_display_pattern.yml
+++ b/resources/locales/xh/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :xh: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"

--- a/resources/locales/zh-Hant/locale_display_pattern.yml
+++ b/resources/locales/zh-Hant/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:zh-Hant: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}：{1}"
+    :localePattern: "{0}（{1}）"
+    :localeSeparator: "{0}，{1}"

--- a/resources/locales/zh-Hant/locale_display_pattern.yml
+++ b/resources/locales/zh-Hant/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :zh-Hant: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}：{1}"
-    :localePattern: "{0}（{1}）"
-    :localeSeparator: "{0}，{1}"
+    :locale_key_type_pattern: "{0}：{1}"
+    :locale_pattern: "{0}（{1}）"
+    :locale_separator: "{0}，{1}"

--- a/resources/locales/zh/locale_display_pattern.yml
+++ b/resources/locales/zh/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :zh: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}：{1}"
-    :localePattern: "{0}（{1}）"
-    :localeSeparator: "{0}，{1}"
+    :locale_key_type_pattern: "{0}：{1}"
+    :locale_pattern: "{0}（{1}）"
+    :locale_separator: "{0}，{1}"

--- a/resources/locales/zh/locale_display_pattern.yml
+++ b/resources/locales/zh/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:zh: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}：{1}"
+    :localePattern: "{0}（{1}）"
+    :localeSeparator: "{0}，{1}"

--- a/resources/locales/zu/locale_display_pattern.yml
+++ b/resources/locales/zu/locale_display_pattern.yml
@@ -1,0 +1,6 @@
+--- 
+:zu: 
+  :locale_display_pattern: 
+    :localeKeyTypePattern: "{0}: {1}"
+    :localePattern: "{0} ({1})"
+    :localeSeparator: "{0}, {1}"

--- a/resources/locales/zu/locale_display_pattern.yml
+++ b/resources/locales/zu/locale_display_pattern.yml
@@ -1,6 +1,6 @@
 --- 
 :zu: 
   :locale_display_pattern: 
-    :localeKeyTypePattern: "{0}: {1}"
-    :localePattern: "{0} ({1})"
-    :localeSeparator: "{0}, {1}"
+    :locale_key_type_pattern: "{0}: {1}"
+    :locale_pattern: "{0} ({1})"
+    :locale_separator: "{0}, {1}"


### PR DESCRIPTION
This adds support for CLDR's [Locale Display Names](https://www.unicode.org/reports/tr35/tr35-general.html#Display_Name_Elements) elements to the gem. It includes:

1. Importer to import the data from the raw data
2. Rake task to run the importer
3. Integration of the importer into `standard_importer_classes` so it runs automatically
4. `LocaleDisplayName` class implementing the Locale Display Name Algorithm

@camertron This is the locale display name stuff I had mentioned wanting to integrate at the SF Ruby meetup late last year. I finally got around to doing a deep-dive into the source and figuring out how to add this!

## Background

At my work, we have a lot of languages available for users to choose from, so we need to display a locale selector showing the names of all these languages, both in the target language itself, and in the currently active language. MT isn't perfect for this, and CLDR already contains all the data necessary to derive these display names, so I wanted to leverage officially vetted data as much as possible.

While there are several gems that bundle and re-export CLDR data, I noticed one flaw common to all of them. Most used CLDR's `<languages>` data, but none used `<localeDisplayPattern>`. The problem with this is that, while `<languages>` does contain the translated names of many languages, it usually does not contain translations of regional variants (e.g. `fr-CA` or `pt-BR`). Perhaps this was not noticed, because English does have overrides for regional variants as English prefers forms like "Brazilian Portuguese", and overrides do appear `<languages>`. But many other languages _do not_ use overrides, meaning regional variants are not represented at all in `<languages>`.

```ruby
TwitterCldr::Shared::Languages.from_code_for_locale("pt-BR", "en")
#=> "Brazilian Portuguese"

TwitterCldr::Shared::Languages.from_code_for_locale("pt-BR", "de")
#=> nil
```

In general, locales with region tags or script tags (`zh-Hant-HK`) will not have specific translations in `<languages>`. To generate display names for these locales, the `<localeDisplayPattern>` must be used.

## This PR

I was pleased to find, after reading the gem's source, that `CldrLocale` already handled inheritance correctly, merging data up to the `root` data set. This is specifically important for `<localeDisplayPattern>` as many languages require inheritance back to `root` in order to derive the correct data.

It was relatively easy to implement `LocaleDisplayPatternImporter` following the example of `TerritoriesImporter`. I ran the importer for the supported locales and spot-checked the results before committing them.

I made `LocaleDisplayName` to implement the algorithm from CLDR. I was also happy to find that `Locale` has a `permutations` method to give me all the combinations of present subtags, as this is part of the algorithm to find the longest pre-translated subtag for use as the base name.

Combining the exported data and the algorithm, I verified that the output is as expected.

```ruby
TwitterCldr::Shared::LocaleDisplayName.from_code_for_locale("zh-HK", :en)
#=> "Chinese (Hong Kong SAR China)"

TwitterCldr::Shared::LocaleDisplayName.new("pt-BR").display_name
#=> "Brazilian Portuguese"

TwitterCldr::Shared::LocaleDisplayName.new("pt-BR", :de).display_name
#=> "Portugiesisch (Brasilien)"
```

I gave `LocaleDisplayName` some class methods that match the API of `Languages`, for consistency.

## Shortcomings

The gem does not currently support script, variant, or T/U subtags, as far as I could tell. These are all part of the full display name algorithm. Since they were not immediately relevant to my use case (displaying regional variants), I omitted them. In the future, I would like to revisit this and add these data points to the gem, so full display names can be generated for any locale.

I wasn't sure if there was anywhere else this should be integrated. Maybe it could be integrated into `Locale` or `LocalizedSymbol`? My usecase didn't need anything more than this, but I'm open to suggestions.