### PR TITLE
Fix ruby 3.4 future frozen string warning

### DIFF
--- a/lib/twitter_cldr/formatters/formatter.rb
+++ b/lib/twitter_cldr/formatters/formatter.rb
@@ -14,7 +14,7 @@ module TwitterCldr
       end
 
       def format(tokens, obj, options = {})
-        tokens.each_with_index.inject("") do |ret, (token, index)|
+        tokens.each_with_index.inject(+"") do |ret, (token, index)|
           method_sym = :"format_#{token.type}"
           ret << send(method_sym, token, index, obj, options)
         end

--- a/lib/twitter_cldr/formatters/plurals/ruby_runtime.rb
+++ b/lib/twitter_cldr/formatters/plurals/ruby_runtime.rb
@@ -1,0 +1,161 @@
+# encoding: UTF-8
+
+# Copyright 2012 Twitter, Inc
+# http://www.apache.org/licenses/LICENSE-2.0
+
+module TwitterCldr
+  module Formatters
+    module Plurals
+      module RubyRuntime
+
+        class StrNum
+          def self.from_string(str)
+            sign, int, frac, exp = str.scan(/([+-])?(\d+)\.?(\d+)?[eEcC]?(-?\d+)?/).flatten
+            new(sign || '', int, frac || '', exp.to_i)
+          end
+
+          attr_reader :sign, :int, :frac, :exp
+
+          def initialize(sign, int, frac, exp)
+            @sign = sign
+            @int = int
+            @frac = frac
+            @exp = exp
+          end
+
+          def int_val
+            int.to_i
+          end
+
+          def frac_val
+            # remove leading zeroes
+            frac.sub(/\A0*/, '')
+          end
+
+          def apply_exp
+            new_int, new_frac = if exp > 0
+              shift_right(exp)
+            else
+              shift_left(exp.abs)
+            end
+
+            self.class.new(sign, new_int || '', new_frac || '', 0)
+          end
+
+          def abs
+            self.class.new('', int, frac, exp)
+          end
+
+          def to_s
+            ''.tap do |result|
+              result << "#{sign}#{int}"
+              result << ".#{frac}" unless frac.empty?
+              result << "e#{exp}" if exp != 0
+            end
+          end
+
+          def strip
+            self.class.new(sign, int, frac.sub(/0+\z/, ''), exp)
+          end
+
+          def to_val
+            str = to_s
+
+            if str.include?('.')
+              str.to_f
+            else
+              str.to_i * (10 ** exp)
+            end
+          end
+
+          private
+
+          def shift_right(n)
+            return [int, frac] if exp == 0
+
+            new_int = "#{int}#{frac[0...n]}"
+
+            if n - frac.length > 0
+              new_int << '0' * (n - frac.length)
+            end
+
+            new_frac = frac[n..-1]
+            new_frac = (!new_frac || new_frac.empty?) && !frac.empty? ? '0' : new_frac
+
+            [new_int, new_frac]
+          end
+
+          def shift_left(n)
+            return [int, frac] if exp == 0
+
+            new_frac = ''
+
+            if n - int.length > 0
+              new_frac << '0' * (n - int.length)
+            end
+
+            new_frac << int[0...n]
+            new_frac << frac
+            new_int = int[n..-1]
+            new_int = !new_int || new_int.empty? ? '0' : new_int
+
+            [new_int, new_frac]
+          end
+        end
+
+        class << self
+          def build_args_for(num_str)
+            num = StrNum.from_string(num_str)
+
+            [
+              n(num), i(num), f(num),
+              t(num), v(num), w(num),
+              e(num)
+            ]
+          end
+
+          # absolute value of the source number (integer and decimals).
+          def n(num)
+            wrap(num).abs.strip.to_val
+          end
+
+          # integer digits of n.
+          def i(num)
+            wrap(num).apply_exp.int_val
+          end
+
+          # visible fractional digits in n, with trailing zeros.
+          def f(num)
+            wrap(num).apply_exp.frac_val.to_i
+          end
+
+          # visible fractional digits in n, without trailing zeros.
+          def t(num)
+            wrap(num).apply_exp.strip.frac_val.to_i
+          end
+
+          # number of visible fraction digits in n, with trailing zeros.
+          def v(num)
+            wrap(num).apply_exp.frac.length
+          end
+
+          # number of visible fraction digits in n, without trailing zeros.
+          def w(num)
+            wrap(num).apply_exp.strip.frac_val.length
+          end
+
+          def e(num)
+            wrap(num).exp
+          end
+
+          private
+
+          def wrap(str_or_num)
+            return str_or_num if str_or_num.is_a?(StrNum)
+            StrNum.from_string(str_or_num)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/twitter_cldr/formatters/plurals/ruby_runtime.rb
+++ b/lib/twitter_cldr/formatters/plurals/ruby_runtime.rb
@@ -47,7 +47,7 @@ module TwitterCldr
           end
 
           def to_s
-            ''.tap do |result|
+            (+'').tap do |result|
               result << "#{sign}#{int}"
               result << ".#{frac}" unless frac.empty?
               result << "e#{exp}" if exp != 0

--- a/lib/twitter_cldr/formatters/plurals/rules.rb
+++ b/lib/twitter_cldr/formatters/plurals/rules.rb
@@ -3,7 +3,7 @@
 # Copyright 2012 Twitter, Inc
 # http://www.apache.org/licenses/LICENSE-2.0
 
-require 'cldr-plurals/ruby_runtime'
+require_relative 'ruby_runtime'
 
 module TwitterCldr
   module Formatters
@@ -23,7 +23,7 @@ module TwitterCldr
           end
 
           def rule_for(number, locale = TwitterCldr.locale, type = DEFAULT_TYPE)
-            rule(locale, type).call(number.to_s, CldrPlurals::RubyRuntime)
+            rule(locale, type).call(number.to_s, Plurals::RubyRuntime)
           rescue
             :other
           end

--- a/twitter_cldr.gemspec
+++ b/twitter_cldr.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   # json gem since v2.0 requries Ruby ~> 2.0
   s.add_dependency 'camertron-eprun'
-  s.add_dependency 'cldr-plurals-runtime-rb', '~> 1.1'
   s.add_dependency 'json', '~> 1.0' if RUBY_VERSION < '2'
   s.add_dependency 'tzinfo'
   s.add_dependency 'base64'


### PR DESCRIPTION
When updating to ruby 3.4.x in my rails project, I get warnings such as these

```
~/.ruby/gems/twitter_cldr-6.12.0/lib/twitter_cldr/formatters/formatter.rb:17: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
~/.ruby/gems/cldr-plurals-runtime-rb-1.1.0/lib/cldr-plurals/ruby-runtime/str_num.rb:44: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

This PR fixes the warnings, and removes the dependency on `cldr-plurals-runtime-rb` since I could not find the maintained repo for that gem, and it is small enough to simply copy into this gem. Let me know if you would prefer me to fix the warning inside that gem itself instead of removing the dependency on it.