### PR TITLE
Fix format that should be skipped

### DIFF
--- a/lib/twitter_cldr/data_readers/number_data_reader.rb
+++ b/lib/twitter_cldr/data_readers/number_data_reader.rb
@@ -25,6 +25,7 @@ module TwitterCldr
       DEFAULT_TYPE = :decimal
       DEFAULT_FORMAT = :default
       DEFAULT_SIGN = :positive
+      NON_COMPACT_PATTERN = "0"
 
       FORMATTERS = {
         decimal: TwitterCldr::Formatters::DecimalFormatter,
@@ -53,6 +54,16 @@ module TwitterCldr
       def format_number(number, options = {})
         precision = options[:precision] || 0
         pattern_for_number = pattern(number, precision == 0)
+
+        # CLDR spec: if pattern is "0", use the corresponding non-compact number formatting
+        # Check pattern before applying sign
+        base_pattern = pattern_for_number.gsub(/^[+-]/, '')
+        if base_pattern == NON_COMPACT_PATTERN
+          # Delegate to a default format reader to avoid state mutation
+          default_reader = self.class.new(locale, type: type, format: :default, number_system: number_system)
+          return default_reader.format_number(number, options)
+        end
+
         options[:locale] = self.locale
         tokens = tokenizer.tokenize(pattern_for_number)
         formatter.format(tokens, number, options)

--- a/spec/localized/localized_number_spec.rb
+++ b/spec/localized/localized_number_spec.rb
@@ -63,6 +63,10 @@ describe TwitterCldr::Localized::LocalizedNumber do
         it "formats the number properly" do
           expect(described_class.new(93_000_000, :ja, type: :decimal, format: :short).to_s).to match_normalized("9300万")
         end
+
+        it "does not abbreviate when pattern is 0" do
+          expect(described_class.new(1234, :ja, type: :decimal, format: :short).to_s).to match_normalized("1,234")
+        end
       end
     end
 


### PR DESCRIPTION
## What
Not compact and use default format when pattern value is `"0"`.

## Why
It is specified in LDML.

https://unicode.org/reports/tr35/tr35-numbers.html

> If the value is precisely “0”, either explicit or defaulted, then the normal number format pattern for that sort of object is supplied — either <decimalFormat> or <currencyFormat type="standard"> — with the normal formatting for the locale (such as the grouping separators). However, for the “0” case by default the significant digits are adjusted for consistency, typically to 2 or 3 digits, and the maximum fractional digits are set to 0 (for both currencies and plain decimal). Thus the output would be $12, not $12.01. APIs may, however, allow these default behaviors to be overridden.

For now, strange conversion occurs. At least in Japanese, it is not correct.

```
wakabayashi1211@P2474 twitter-cldr-rb % bundle exec irb
irb(main):001> require 'twitter_cldr'
=> true
irb(main):002> TwitterCldr::Localized::LocalizedNumber.new(9876, :ja).to_s(format: :short)
=> "10"
irb(main):003> 
```

## Anything else
I have two questions.

- Is this expected behavior? If so, we should change only Japanese format (I'm afraid I'm not very knowledgeable about other languages).
- If this behavior should be fixed, how should we handle decimal parts?